### PR TITLE
feat: 검색 페이지 마크업 구현

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,9 @@
 import type { NextPage } from 'next'
-import PostCard from '@components/PostCard'
+import MenuCard from '@components/MenuCard'
 import { useState } from 'react'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { Card, PostCardDummy } from '@constants/cardData'
+import styled from '@emotion/styled'
 
 const Home: NextPage = () => {
   const [cards, setCards] = useState(PostCardDummy)
@@ -15,10 +16,10 @@ const Home: NextPage = () => {
   )
 
   return (
-    <>
+    <CardListWrapper>
       {cards.map((cardData, idx) => {
         return (
-          <PostCard
+          <MenuCard
             id={cardData.id}
             key={idx}
             title={cardData.title}
@@ -31,8 +32,20 @@ const Home: NextPage = () => {
           />
         )
       })}
-    </>
+    </CardListWrapper>
   )
 }
+
+const CardListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: scroll;
+  row-gap: 1rem;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`
 
 export default Home

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ const Home: NextPage = () => {
         return (
           <PostCard
             id={cardData.id}
-            key={idx.toString()}
+            key={idx}
             title={cardData.title}
             imageUrl={cardData.imageUrl}
             avatarImageUrl={cardData.avatarImageUrl}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,29 +1,8 @@
 import type { NextPage } from 'next'
 import PostCard from '@components/PostCard'
 import { useState } from 'react'
-import useIntersectionObserver from '../src/hooks/useIntersectionObserver'
-
-const Card = {
-  id: '12341324',
-  title: '참치마요',
-  imageUrl: 'https://via.placeholder.com/300x150',
-  avatarImageUrl: 'https://via.placeholder.com/50',
-  author: 'Lee',
-  likes: 10,
-  comments: 20
-}
-
-const PostCardDummy = Array.from({ length: 4 }, (_, idx) => {
-  return {
-    id: idx.toString(),
-    title: '참치마요',
-    imageUrl: 'https://via.placeholder.com/300x150',
-    avatarImageUrl: 'https://via.placeholder.com/50',
-    author: 'Lee',
-    likes: 10,
-    comments: 20
-  }
-})
+import useIntersectionObserver from '@hooks/useIntersectionObserver'
+import { Card, PostCardDummy } from '@constants/cardData'
 
 const Home: NextPage = () => {
   const [cards, setCards] = useState(PostCardDummy)

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -1,0 +1,98 @@
+import Input from '@components/Input'
+import PostCard from '@components/PostCard'
+import styled from '@emotion/styled'
+import useIntersectionObserver from '@hooks/useIntersectionObserver'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+
+const Card = {
+  id: '12341324',
+  title: '참치마요',
+  imageUrl: 'https://via.placeholder.com/300x150',
+  avatarImageUrl: 'https://via.placeholder.com/50',
+  author: 'Lee',
+  likes: 10,
+  comments: 20
+}
+
+const PostCardDummy = Array.from({ length: 4 }, (_, idx) => {
+  return {
+    id: idx.toString(),
+    title: '참치마요',
+    imageUrl: 'https://via.placeholder.com/300x150',
+    avatarImageUrl: 'https://via.placeholder.com/50',
+    author: 'Lee',
+    likes: 10,
+    comments: 20
+  }
+})
+
+const Search = () => {
+  const [cards, setCards] = useState(PostCardDummy)
+  const ref = useIntersectionObserver(
+    async (entry, observer) => {
+      observer.unobserve(entry.target)
+      setCards([...cards, Card])
+    },
+    { threshold: 0.5 }
+  )
+  const router = useRouter()
+  const { category } = router.query
+  return (
+    <>
+      <Container>
+        <Input height={5} type="text" placeholder="검색해라" />
+        <CategoryHeader>스타벅스</CategoryHeader>
+        <Wrapper>
+          {cards.map((cardData, idx) => {
+            return (
+              <PostCard
+                id={cardData.id}
+                key={idx.toString()}
+                title={cardData.title}
+                imageUrl={cardData.imageUrl}
+                avatarImageUrl={cardData.avatarImageUrl}
+                author={cardData.author}
+                likes={cardData.likes}
+                comments={cardData.comments}
+                divRef={cards.length === idx + 1 ? ref : null}
+              />
+            )
+          })}
+        </Wrapper>
+      </Container>
+    </>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+  gap: 1rem;
+  height: 100%;
+`
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: scroll;
+  row-gap: 1rem;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`
+
+const CategoryHeader = styled.div`
+  height: 8rem;
+  font-size: 2rem;
+  text-align: center;
+  padding: 3rem;
+  background-color: gray;
+  box-sizing: border-box;
+  user-select: none;
+`
+
+export default Search

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -8,6 +8,8 @@ import { useState } from 'react'
 import { FiSearch } from 'react-icons/fi'
 import { BsFilterLeft } from 'react-icons/bs'
 
+const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
+
 const Search = () => {
   const [cards, setCards] = useState(PostCardDummy)
   const ref = useIntersectionObserver(
@@ -24,7 +26,11 @@ const Search = () => {
     <>
       <Container>
         <SearchWrapper>
-          <SearchInput height={5} type="text" placeholder="검색해라" />
+          <SearchInput
+            height={5}
+            type="text"
+            placeholder={`${category} 메뉴 검색`}
+          />
           <SearchIcon />
         </SearchWrapper>
         <CategoryHeader>{category}</CategoryHeader>
@@ -34,9 +40,11 @@ const Search = () => {
             <Text>필터</Text>
           </FilterWrapper>
           <select>
-            <option>최신순</option>
-            <option>좋아요순</option>
-            <option>댓글순</option>
+            {SORT_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
           </select>
         </FilterContainer>
         <Wrapper>

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -23,49 +23,47 @@ const Search = () => {
   const { category } = router.query
 
   return (
-    <>
-      <Container>
-        <SearchWrapper>
-          <SearchInput
-            height={5}
-            type="text"
-            placeholder={`${category} 메뉴 검색`}
-          />
-          <SearchIcon />
-        </SearchWrapper>
-        <CategoryHeader>{category}</CategoryHeader>
-        <FilterContainer>
-          <FilterWrapper>
-            <FilterIcon />
-            <Text>필터</Text>
-          </FilterWrapper>
-          <select>
-            {SORT_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
-          </select>
-        </FilterContainer>
-        <CardListWrapper>
-          {cards.map((cardData, idx) => {
-            return (
-              <MenuCard
-                id={cardData.id}
-                key={idx}
-                title={cardData.title}
-                imageUrl={cardData.imageUrl}
-                avatarImageUrl={cardData.avatarImageUrl}
-                author={cardData.author}
-                likes={cardData.likes}
-                comments={cardData.comments}
-                divRef={cards.length === idx + 1 ? ref : null}
-              />
-            )
-          })}
-        </CardListWrapper>
-      </Container>
-    </>
+    <Container>
+      <SearchWrapper>
+        <SearchInput
+          height={5}
+          type="text"
+          placeholder={`${category} 메뉴 검색`}
+        />
+        <SearchIcon />
+      </SearchWrapper>
+      <CategoryHeader>{category}</CategoryHeader>
+      <OptionContainer>
+        <FilterWrapper>
+          <FilterIcon />
+          <Text>필터</Text>
+        </FilterWrapper>
+        <select>
+          {SORT_OPTIONS.map((value) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </select>
+      </OptionContainer>
+      <CardListWrapper>
+        {cards.map((cardData, idx) => {
+          return (
+            <MenuCard
+              id={cardData.id}
+              key={idx}
+              title={cardData.title}
+              imageUrl={cardData.imageUrl}
+              avatarImageUrl={cardData.avatarImageUrl}
+              author={cardData.author}
+              likes={cardData.likes}
+              comments={cardData.comments}
+              divRef={cards.length === idx + 1 ? ref : null}
+            />
+          )
+        })}
+      </CardListWrapper>
+    </Container>
   )
 }
 
@@ -90,7 +88,7 @@ const SearchIcon = styled(FiSearch)`
   margin-left: -3.5rem;
 `
 
-const FilterContainer = styled.div`
+const OptionContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   gap: 1rem;

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -2,30 +2,11 @@ import Input from '@components/Input'
 import PostCard from '@components/PostCard'
 import styled from '@emotion/styled'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
+import { Card, PostCardDummy } from '@constants/cardData'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-
-const Card = {
-  id: '12341324',
-  title: '참치마요',
-  imageUrl: 'https://via.placeholder.com/300x150',
-  avatarImageUrl: 'https://via.placeholder.com/50',
-  author: 'Lee',
-  likes: 10,
-  comments: 20
-}
-
-const PostCardDummy = Array.from({ length: 4 }, (_, idx) => {
-  return {
-    id: idx.toString(),
-    title: '참치마요',
-    imageUrl: 'https://via.placeholder.com/300x150',
-    avatarImageUrl: 'https://via.placeholder.com/50',
-    author: 'Lee',
-    likes: 10,
-    comments: 20
-  }
-})
+import { FiSearch } from 'react-icons/fi'
+import { BsFilterLeft } from 'react-icons/bs'
 
 const Search = () => {
   const [cards, setCards] = useState(PostCardDummy)
@@ -38,11 +19,26 @@ const Search = () => {
   )
   const router = useRouter()
   const { category } = router.query
+
   return (
     <>
       <Container>
-        <Input height={5} type="text" placeholder="검색해라" />
-        <CategoryHeader>스타벅스</CategoryHeader>
+        <SearchWrapper>
+          <SearchInput height={5} type="text" placeholder="검색해라" />
+          <SearchIcon />
+        </SearchWrapper>
+        <CategoryHeader>{category}</CategoryHeader>
+        <FilterContainer>
+          <FilterWrapper>
+            <FilterIcon />
+            <Text>필터</Text>
+          </FilterWrapper>
+          <select>
+            <option>최신순</option>
+            <option>좋아요순</option>
+            <option>댓글순</option>
+          </select>
+        </FilterContainer>
         <Wrapper>
           {cards.map((cardData, idx) => {
             return (
@@ -73,6 +69,37 @@ const Container = styled.div`
   height: 100%;
 `
 
+const SearchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+const SearchInput = styled(Input)`
+  width: 100%;
+`
+
+const SearchIcon = styled(FiSearch)`
+  font-size: 2.5rem;
+  margin-left: -3.5rem;
+`
+
+const FilterContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+`
+
+const FilterWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+`
+
+const FilterIcon = styled(BsFilterLeft)`
+  font-size: 3.5rem;
+  font-weight: bold;
+`
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -92,6 +119,11 @@ const CategoryHeader = styled.div`
   padding: 3rem;
   background-color: gray;
   box-sizing: border-box;
+  user-select: none;
+`
+
+const Text = styled.span`
+  font-size: 2rem;
   user-select: none;
 `
 

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -52,7 +52,7 @@ const Search = () => {
             return (
               <PostCard
                 id={cardData.id}
-                key={idx.toString()}
+                key={idx}
                 title={cardData.title}
                 imageUrl={cardData.imageUrl}
                 avatarImageUrl={cardData.avatarImageUrl}

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -1,5 +1,5 @@
 import Input from '@components/Input'
-import PostCard from '@components/PostCard'
+import MenuCard from '@components/MenuCard'
 import styled from '@emotion/styled'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { Card, PostCardDummy } from '@constants/cardData'
@@ -47,10 +47,10 @@ const Search = () => {
             ))}
           </select>
         </FilterContainer>
-        <Wrapper>
+        <CardListWrapper>
           {cards.map((cardData, idx) => {
             return (
-              <PostCard
+              <MenuCard
                 id={cardData.id}
                 key={idx}
                 title={cardData.title}
@@ -63,7 +63,7 @@ const Search = () => {
               />
             )
           })}
-        </Wrapper>
+        </CardListWrapper>
       </Container>
     </>
   )
@@ -108,7 +108,7 @@ const FilterIcon = styled(BsFilterLeft)`
   font-weight: bold;
 `
 
-const Wrapper = styled.div`
+const CardListWrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,0 +1,5 @@
+const Category = () => {
+  return <div>hi</div>
+}
+
+export default Category

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -4,7 +4,6 @@ import { IoMdHeartEmpty } from 'react-icons/io'
 import { BiComment } from 'react-icons/bi'
 import Link from 'next/link'
 import { RefObject } from 'react'
-import { FiSearch } from 'react-icons/fi'
 
 interface Props {
   id: string
@@ -19,7 +18,7 @@ interface Props {
 
 const IMAGE_ALT = 'NO IMAGE'
 
-const PostCard = ({
+const MenuCard = ({
   id,
   title,
   imageUrl,
@@ -102,4 +101,4 @@ const Text = styled.div`
   user-select: none;
 `
 
-export default PostCard
+export default MenuCard

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,6 +4,7 @@ import { IoMdHeartEmpty } from 'react-icons/io'
 import { BiComment } from 'react-icons/bi'
 import Link from 'next/link'
 import { RefObject } from 'react'
+import { FiSearch } from 'react-icons/fi'
 
 interface Props {
   id: string
@@ -52,6 +53,8 @@ const PostCard = ({
 
 const CardContainer = styled.div`
   width: 100%;
+  border-radius: 1rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(55, 31, 31, 0.2);
   cursor: pointer;
 `
 
@@ -60,6 +63,7 @@ const Title = styled.div`
   font-size: 2rem;
   text-align: center;
   box-sizing: border-box;
+  user-select: none;
 `
 
 const Image = styled.img`
@@ -82,6 +86,7 @@ const UserInfoWrapper = styled.div`
 const Author = styled.div`
   font-size: 1.6rem;
   font-weight: bold;
+  user-select: none;
 `
 
 const PostInfoWrapper = styled.div`
@@ -94,6 +99,7 @@ const PostInfoWrapper = styled.div`
 
 const Text = styled.div`
   font-size: 2rem;
+  user-select: none;
 `
 
 export default PostCard

--- a/src/constants/cardData.ts
+++ b/src/constants/cardData.ts
@@ -1,0 +1,21 @@
+export const Card = {
+  id: '12341324',
+  title: '참치마요',
+  imageUrl: 'https://via.placeholder.com/300x150',
+  avatarImageUrl: 'https://via.placeholder.com/50',
+  author: 'Lee',
+  likes: 10,
+  comments: 20
+}
+
+export const PostCardDummy = Array.from({ length: 4 }, (_, idx) => {
+  return {
+    id: idx.toString(),
+    title: '참치마요',
+    imageUrl: 'https://via.placeholder.com/300x150',
+    avatarImageUrl: 'https://via.placeholder.com/50',
+    author: 'Lee',
+    likes: 10,
+    comments: 20
+  }
+})


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #28
resolve #29 

## 📌 기능 설명

피그마 시안대로 검색 페이지 마크업을 구현했습니다.


## 👩‍💻 요구 사항과 구현 내용

- 검색 Input 구현
- 카테고리 헤더 구현
- 정렬 select 구현
- 필터 선택 버튼 구현

MenuCard, InfiniteScroll은 MainPage에서 구현한 컴포넌트와 hook을 사용했습니다. (#9) / (#26)

## 구현 결과

![searchPage](https://user-images.githubusercontent.com/81891292/181183940-2b4613ff-7dfa-4f61-bc80-4888314e63c9.PNG)

