### PR TITLE
refactor(Navigation): 아이콘 active 속성을 selected로 변경 및 타입 boolean으로 수정

### DIFF
--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -16,7 +16,7 @@ const { mainPink, mainWhite, borderLight } = theme.color
 const { navHeight, pagePadding } = theme.layout
 
 type IconType = {
-  isactive?: number
+  selected?: boolean
 }
 
 export const Navigation = () => {
@@ -29,21 +29,21 @@ export const Navigation = () => {
         <NavItem>
           <Link href={HOME_URL}>
             <a>
-              <StyledHome isactive={pathname === HOME_URL ? 1 : 0} />
+              <StyledHome selected={pathname === HOME_URL} />
             </a>
           </Link>
         </NavItem>
         <NavItem>
           <Link href={CREATE_MENU_URL}>
             <a>
-              <StyledPlus isactive={pathname === CREATE_MENU_URL ? 1 : 0} />
+              <StyledPlus selected={pathname === CREATE_MENU_URL} />
             </a>
           </Link>
         </NavItem>
         <NavItem>
           <Link href={SEARCH_URL}>
             <a>
-              <StyledSearch isactive={pathname === SEARCH_URL ? 1 : 0} />
+              <StyledSearch selected={pathname === SEARCH_URL} />
             </a>
           </Link>
         </NavItem>
@@ -51,7 +51,7 @@ export const Navigation = () => {
           {/* //todo신영 USER_URL 뒤에 /userId query param 넘겨주기 */}
           <Link href={USER_URL}>
             <a>
-              <StyledMenu isactive={pathname === USER_URL ? 1 : 0} />
+              <StyledMenu selected={pathname === USER_URL} />
             </a>
           </Link>
         </NavItem>
@@ -101,25 +101,25 @@ const NavItem = styled.li`
 const StyledHome = styled(BiHomeAlt)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ isactive }) => isactive && theme.color.mainPink};
+  color: ${({ selected }) => selected && theme.color.mainPink};
 `
 
 const StyledPlus = styled(AiOutlinePlusSquare)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ isactive }) => isactive && theme.color.mainPink};
+  color: ${({ selected }) => selected && theme.color.mainPink};
 `
 
 const StyledSearch = styled(BiSearch)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ isactive }) => isactive && theme.color.mainPink};
+  color: ${({ selected }) => selected && theme.color.mainPink};
 `
 
 const StyledMenu = styled(VscBook)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ isactive }) => isactive && theme.color.mainPink};
+  color: ${({ selected }) => selected && theme.color.mainPink};
 `
 
 export default Navigation


### PR DESCRIPTION

## 📌 기능 설명

하단 Navigation의 속성명을 selected로 변경 후 타입을 boolean으로 변경


## 👩‍💻 요구 사항과 구현 내용

![image](https://user-images.githubusercontent.com/79133602/181431157-83e7d57b-163d-422e-b532-d82760d7efdc.png)

- isactive, active에서 non boolean에 boolean 타입을 줄 수 없다는 에러는 Icon에 이미 active, isactive 속성이 boolean이 아닌 상태로 존재했기 때문이었네요 ㅜ 
- selected로 바꾸니 타입 문제가 해결됐습니다.

