### PR TITLE
feat: 유저 메뉴 페이지 마크업 구현

### DIFF
--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -9,7 +9,6 @@ import { BsFilterLeft } from 'react-icons/bs'
 import { FiSearch } from 'react-icons/fi'
 
 const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
-
 const dummy = ['작성한 메뉴', '좋아요한 메뉴']
 
 interface TabProps {
@@ -21,6 +20,7 @@ interface TabProps {
 const UserMenuPage = () => {
   const [option, setOption] = useState(dummy[0])
   const [cards, setCards] = useState(PostCardDummy)
+
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       observer.unobserve(entry.target)
@@ -36,65 +36,92 @@ const UserMenuPage = () => {
 
   return (
     <>
-      <ProfileContainer>
-        <Avatar
-          size={10}
-          src={'https://via.placeholder.com/100'}
-          isLoading={false}
-        />
-        <Author>작성자</Author>
-      </ProfileContainer>
-      <TabContainer>
-        {dummy.map((val) => (
-          <Tab
-            key={val}
-            selected={option === val}
-            value={val}
-            onClick={handleClick}
-          >
-            {val}
-          </Tab>
-        ))}
-      </TabContainer>
-      <Container>
-        <SearchWrapper>
-          <SearchInput height={5} type="text" placeholder={`메뉴 검색`} />
-          <SearchIcon />
-        </SearchWrapper>
-        <OptionContainer>
-          <FilterWrapper>
-            <FilterIcon />
-            <Text>필터</Text>
-          </FilterWrapper>
-          <select>
-            {SORT_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
+      <FixedWrapper>
+        <InnerWrapper>
+          <ProfileContainer>
+            <Avatar
+              size={10}
+              src={'https://via.placeholder.com/100'}
+              isLoading={false}
+            />
+            <Author>작성자</Author>
+          </ProfileContainer>
+          <TabContainer>
+            {dummy.map((val) => (
+              <Tab
+                key={val}
+                selected={option === val}
+                value={val}
+                onClick={handleClick}
+              >
+                {val}
+              </Tab>
             ))}
-          </select>
-        </OptionContainer>
-        <CardListWrapper>
-          {cards.map((cardData, idx) => {
-            return (
-              <MenuCard
-                id={cardData.id}
-                key={idx}
-                title={cardData.title}
-                imageUrl={cardData.imageUrl}
-                avatarImageUrl={cardData.avatarImageUrl}
-                author={cardData.author}
-                likes={cardData.likes}
-                comments={cardData.comments}
-                divRef={cards.length === idx + 1 ? ref : null}
-              />
-            )
-          })}
-        </CardListWrapper>
-      </Container>
+          </TabContainer>
+          <SearchWrapper>
+            <SearchInput height={5} type="text" placeholder={`메뉴 검색`} />
+            <SearchIcon />
+          </SearchWrapper>
+          <OptionContainer>
+            <FilterWrapper>
+              <FilterIcon />
+              <Text>필터</Text>
+            </FilterWrapper>
+            <select>
+              {SORT_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </OptionContainer>
+        </InnerWrapper>
+      </FixedWrapper>
+
+      <CardListWrapper>
+        {cards.map((cardData, idx) => {
+          return (
+            <MenuCard
+              id={cardData.id}
+              key={idx}
+              title={cardData.title}
+              imageUrl={cardData.imageUrl}
+              avatarImageUrl={cardData.avatarImageUrl}
+              author={cardData.author}
+              likes={cardData.likes}
+              comments={cardData.comments}
+              divRef={cards.length === idx + 1 ? ref : null}
+            />
+          )
+        })}
+      </CardListWrapper>
     </>
   )
 }
+
+const FixedWrapper = styled.div`
+  position: fixed;
+  left: 0;
+  width: 100%;
+`
+
+const InnerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 33.5rem;
+  max-width: 46rem;
+  width: 100%;
+  background-color: white;
+  margin: 0 auto;
+  padding-bottom: 1rem;
+  box-sizing: border-box;
+
+  @media screen and (max-width: 31.25rem) {
+    padding: 0 2rem;
+  }
+`
+
 const ProfileContainer = styled.div`
   padding: 2rem;
   display: flex;
@@ -124,14 +151,6 @@ const Tab = styled.button<TabProps>`
   font-weight: bold;
   border-bottom: ${({ selected }) => (selected ? '3px solid red' : 'none')};
   height: 5rem;
-`
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-top: 1rem;
-  gap: 1rem;
-  height: 100%;
 `
 
 const SearchWrapper = styled.div`
@@ -166,10 +185,9 @@ const FilterIcon = styled(BsFilterLeft)`
 `
 
 const CardListWrapper = styled.div`
+  padding-top: 31.25rem;
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: scroll;
   row-gap: 1rem;
 
   ::-webkit-scrollbar {

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -9,8 +9,8 @@ import { BsFilterLeft } from 'react-icons/bs'
 import { FiSearch } from 'react-icons/fi'
 
 const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
-const dummy = ['작성한 메뉴', '좋아요한 메뉴']
-
+const SELECT_DUMMY = ['작성한 메뉴', '좋아요한 메뉴']
+const SIZE_100_IMG_URL = 'https://via.placeholder.com/100'
 interface TabProps {
   selected: boolean
   value: string
@@ -18,7 +18,7 @@ interface TabProps {
 }
 
 const UserMenuPage = () => {
-  const [option, setOption] = useState(dummy[0])
+  const [option, setOption] = useState(SELECT_DUMMY[0])
   const [cards, setCards] = useState(PostCardDummy)
 
   const ref = useIntersectionObserver(
@@ -39,22 +39,18 @@ const UserMenuPage = () => {
       <FixedWrapper>
         <InnerWrapper>
           <ProfileContainer>
-            <Avatar
-              size={10}
-              src={'https://via.placeholder.com/100'}
-              isLoading={false}
-            />
+            <Avatar size={10} src={SIZE_100_IMG_URL} isLoading={false} />
             <Author>작성자</Author>
           </ProfileContainer>
           <TabContainer>
-            {dummy.map((val) => (
+            {SELECT_DUMMY.map((selectOption) => (
               <Tab
-                key={val}
-                selected={option === val}
-                value={val}
+                key={selectOption}
+                selected={option === selectOption}
+                value={selectOption}
                 onClick={handleClick}
               >
-                {val}
+                {selectOption}
               </Tab>
             ))}
           </TabContainer>

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -1,0 +1,185 @@
+import Avatar from '@components/Avatar'
+import Input from '@components/Input'
+import MenuCard from '@components/MenuCard'
+import { Card, PostCardDummy } from '@constants/cardData'
+import styled from '@emotion/styled'
+import useIntersectionObserver from '@hooks/useIntersectionObserver'
+import { MouseEvent, useState } from 'react'
+import { BsFilterLeft } from 'react-icons/bs'
+import { FiSearch } from 'react-icons/fi'
+
+const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
+
+const dummy = ['작성한 메뉴', '좋아요한 메뉴']
+
+interface TabProps {
+  selected: boolean
+  value: string
+  onClick: (e: MouseEvent<HTMLElement>) => void
+}
+
+const UserMenuPage = () => {
+  const [option, setOption] = useState(dummy[0])
+  const [cards, setCards] = useState(PostCardDummy)
+  const ref = useIntersectionObserver(
+    async (entry, observer) => {
+      observer.unobserve(entry.target)
+      setCards([...cards, Card])
+    },
+    { threshold: 0.5 }
+  )
+
+  const handleClick = (e: MouseEvent<HTMLElement>) => {
+    const divElement = e.target as HTMLElement
+    setOption(divElement.innerText)
+  }
+
+  return (
+    <>
+      <ProfileContainer>
+        <Avatar
+          size={10}
+          src={'https://via.placeholder.com/100'}
+          isLoading={false}
+        />
+        <Author>작성자</Author>
+      </ProfileContainer>
+      <TabContainer>
+        {dummy.map((val) => (
+          <Tab
+            key={val}
+            selected={option === val}
+            value={val}
+            onClick={handleClick}
+          >
+            {val}
+          </Tab>
+        ))}
+      </TabContainer>
+      <Container>
+        <SearchWrapper>
+          <SearchInput height={5} type="text" placeholder={`메뉴 검색`} />
+          <SearchIcon />
+        </SearchWrapper>
+        <OptionContainer>
+          <FilterWrapper>
+            <FilterIcon />
+            <Text>필터</Text>
+          </FilterWrapper>
+          <select>
+            {SORT_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </OptionContainer>
+        <CardListWrapper>
+          {cards.map((cardData, idx) => {
+            return (
+              <MenuCard
+                id={cardData.id}
+                key={idx}
+                title={cardData.title}
+                imageUrl={cardData.imageUrl}
+                avatarImageUrl={cardData.avatarImageUrl}
+                author={cardData.author}
+                likes={cardData.likes}
+                comments={cardData.comments}
+                divRef={cards.length === idx + 1 ? ref : null}
+              />
+            )
+          })}
+        </CardListWrapper>
+      </Container>
+    </>
+  )
+}
+const ProfileContainer = styled.div`
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+`
+
+const Author = styled.div`
+  font-size: 2.4rem;
+  font-weight: bold;
+  user-select: none;
+`
+
+const TabContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+`
+
+const Tab = styled.button<TabProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #ffffff;
+  border: none;
+  padding: 0 2rem;
+  font-size: 2.2rem;
+  font-weight: bold;
+  border-bottom: ${({ selected }) => (selected ? '3px solid red' : 'none')};
+  height: 5rem;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+  gap: 1rem;
+  height: 100%;
+`
+
+const SearchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+const SearchInput = styled(Input)`
+  width: 100%;
+`
+
+const SearchIcon = styled(FiSearch)`
+  font-size: 2.5rem;
+  margin-left: -3.5rem;
+`
+
+const OptionContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+`
+
+const FilterWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+`
+
+const FilterIcon = styled(BsFilterLeft)`
+  font-size: 3.5rem;
+  font-weight: bold;
+`
+
+const CardListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: scroll;
+  row-gap: 1rem;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`
+
+const Text = styled.span`
+  font-size: 2rem;
+  user-select: none;
+`
+
+export default UserMenuPage

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -53,7 +53,6 @@ const MenuCard = ({
 const CardContainer = styled.div`
   width: 100%;
   border-radius: 1rem;
-  box-shadow: 0 0.25rem 0.75rem rgba(55, 31, 31, 0.2);
   cursor: pointer;
 `
 


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #46 

## 📌 기능 설명

유저가 작성한 메뉴, 좋아요한 메뉴 정보를 확인하는 페이지 마크업 구현

## 👩‍💻 요구 사항과 구현 내용

앱 영역 스크롤을 하는 형태에서 페이지 자체를 스크롤 하는 형태로 레이아웃을 수정 적용했습니다.

## 구현 결과
![user](https://user-images.githubusercontent.com/81891292/181680404-39742e56-84ac-479b-b7f9-130099990320.PNG)


