### PR TITLE
feat: currentUser Recoil 구축

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.4.0",
-        "react-query": "^4.0.0"
+        "react-query": "^4.0.0",
+        "recoil": "^0.7.4"
       },
       "devDependencies": {
         "@types/node": "18.0.6",
@@ -2796,6 +2797,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4259,6 +4265,25 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/regenerator-runtime": {
@@ -6960,6 +6985,11 @@
         "slash": "^3.0.0"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7910,6 +7940,14 @@
           "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
           "requires": {}
         }
+      }
+    },
+    "recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.4.0",
-    "react-query": "^4.0.0"
+    "react-query": "^4.0.0",
+    "recoil": "^0.7.4"
   },
   "devDependencies": {
     "@types/node": "18.0.6",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,12 +3,15 @@ import Layout from '@components/Layout'
 import type { AppProps } from 'next/app'
 import { ThemeProvider } from '@emotion/react'
 import theme from '@constants/theme'
+import { RecoilRoot } from 'recoil'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>
       <Layout>
-        <Component {...pageProps} />
+        <RecoilRoot>
+          <Component {...pageProps} />
+        </RecoilRoot>
       </Layout>
     </ThemeProvider>
   )

--- a/src/interfaces/User.ts
+++ b/src/interfaces/User.ts
@@ -1,0 +1,11 @@
+export interface UserType {
+  id: number
+  image: string
+  role: string
+  email: string
+  nickname: string
+  snsAccount: string
+  createdAt: string
+  updatedAt: string
+  menuCount: number
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,7 +1,7 @@
-export interface UserType {
+export interface User {
   id: number
   image: string
-  role: string
+  role: 'ROLE_ACCOUNT' | 'ROLE_ADMIN'
   email: string
   nickname: string
   snsAccount: string

--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil'
+import { UserType } from '@interfaces/User'
+
+export const currentUser = atom<UserType>({
+  key: 'currentUser',
+  default: {
+    id: 1,
+    image:
+      'https://user-images.githubusercontent.com/79133602/181918487-b0e0d98c-3520-40f2-947b-7ba9f4422cd4.PNG',
+    role: 'Regular',
+    email: 'example@naver.com',
+    nickname: '계란이 좋아',
+    snsAccount: 'example@naver.com',
+    createdAt: '2022-07-28T15:10:59.2186394',
+    updatedAt: '2022-07-28T15:10:59.2186394',
+    menuCount: 0
+  }
+})

--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -1,13 +1,13 @@
 import { atom } from 'recoil'
-import { UserType } from '@interfaces/User'
+import { User } from '@interfaces'
 
-export const currentUser = atom<UserType>({
+export const currentUser = atom<User>({
   key: 'currentUser',
   default: {
     id: 1,
     image:
       'https://user-images.githubusercontent.com/79133602/181918487-b0e0d98c-3520-40f2-947b-7ba9f4422cd4.PNG',
-    role: 'Regular',
+    role: 'ROLE_ACCOUNT',
     email: 'example@naver.com',
     nickname: '계란이 좋아',
     snsAccount: 'example@naver.com',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,14 @@
       "@hooks/*": ["src/hooks/*"],
       "@interfaces": ["src/interfaces/index"],
       "@interfaces/*": ["src/interfaces/*"],
+      "@lib/*": ["src/lib/*"],
+      "@axios/*": ["src/lib/axios/*"],
+      "@api/*": ["src/lib/api/*"],
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],
-      "@utils/*": ["src/utils/*"],
       "@customTypes/*": ["src/types/*"],
-      "@recoil/*": ["src/recoil/*"]
+      "@utils/*": ["src/utils/*"],
+      "@types/*": ["src/types/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],
       "@utils/*": ["src/utils/*"],
-      "@customTypes/*": ["src/types/*"]
+      "@customTypes/*": ["src/types/*"],
+      "@recoil/*": ["src/recoil/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],
       "@utils/*": ["src/utils/*"],
-      "@types/*": ["src/types/*"]
+      "@customTypes/*": ["src/types/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
       "@api/*": ["src/lib/api/*"],
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],
-      "@customTypes/*": ["src/types/*"],
       "@utils/*": ["src/utils/*"],
       "@types/*": ["src/types/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
       "@hooks/*": ["src/hooks/*"],
+      "@interfaces": ["src/interfaces/index"],
       "@interfaces/*": ["src/interfaces/*"],
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #53 

## 📌 기능 설명

- recoil 설치 후 현재 인증한 사용자 정보를 atom으로 관리하도록 구현

## 👩‍💻 요구 사항과 구현 내용

### _app: RecoilRoot가 atom을 전역에 공급

![image](https://user-images.githubusercontent.com/79133602/181919895-84ada718-ea4a-4f97-b06e-0f86266ec431.png)

### 📁 recoil

> atom을 관리하는 폴더

현재 currentUser 파일에 인증한 사용자 정보를 atom으로 만들어 뒀습니다.  default는 테스트를 위해 더미를 넣어뒀습니다. 이후에 api를 호출할 수 있게 되면 수정하겠습니다.

![image](https://user-images.githubusercontent.com/79133602/181920069-e589e980-6e02-4610-a7a2-85648cf729f2.png)

### 사용방법
useState와 유사합니다. 기본 값으로 atom을 가져와서 넣어주시면 됩니다.
![image](https://user-images.githubusercontent.com/79133602/181920147-5cca4ea7-9111-4d7b-97d8-b79303dec30c.png)

### 주의 
현재 dummy currentUser의 image는 외부 소스입니다. Image 컴포넌트에 해당 소스를 넣으시려면 next.config.js파일에 다음과 같이 외부 소스 도메인을 입력해줘야 합니다.
![image](https://user-images.githubusercontent.com/79133602/181920231-14ea81de-42a5-4abd-abe5-ef5345ee9c4a.png)

## 구현 결과

![image](https://user-images.githubusercontent.com/79133602/181919856-3dc00512-f33d-4ff0-80b6-cb6a8e7d30c8.png)
