### PR TITLE
fix: interceptor localToken 에러, window is not defined 해결

### DIFF
--- a/src/lib/axios/localToken.ts
+++ b/src/lib/axios/localToken.ts
@@ -1,15 +1,18 @@
 const LOCAL_TOKEN_KEY = 'tastyToken'
-const storage = window.localStorage
 
 export const getLocalToken = () => {
-  const token = storage.getItem(LOCAL_TOKEN_KEY)
+  const token =
+    typeof window !== undefined && window.localStorage.getItem(LOCAL_TOKEN_KEY)
   return token
 }
 
 export const setLocalToken = (token: string) => {
-  return storage.setItem(LOCAL_TOKEN_KEY, token)
+  return (
+    typeof window !== undefined &&
+    window.localStorage.setItem(LOCAL_TOKEN_KEY, token)
+  )
 }
 
 export const removeLocalToken = () => {
-  storage.removeItem(LOCAL_TOKEN_KEY)
+  typeof window !== undefined && window.localStorage.removeItem(LOCAL_TOKEN_KEY)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
       "@mutations/*": ["src/mutations/*"],
       "@queries/*": ["src/queries/*"],
       "@customTypes/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"],,
+      "@utils/*": ["src/utils/*"],
       "@recoil/*": ["src/recoil/*"]
     },
     "target": "es5",


### PR DESCRIPTION
## ✅ 이슈 번호
#52 
## 📌 기능 설명

- axiosInstance 사용시 window is not defined 에러 해결

## 👩‍💻 요구 사항과 구현 내용


### 에러 발생 원인
- NEXT JS는 SSR 방식, 서버에선 window localStorage에 접근하지 못하기 때문에 발생한 오류
- token은 null이어도 axsios 자체의 에러가 나지 않습니다. 
### 해결 
- page가 loaded되고 window가 defined된 시점에 localStrorage에 접근하도록 조건문 추가 
![image](https://user-images.githubusercontent.com/79133602/182199799-2117bc28-6290-4244-9bd7-930c6e1f7e20.png)



## 구현 결과

- 전
![image](https://user-images.githubusercontent.com/79133602/182199224-67b89155-abd7-48dc-9d8c-cd83a1a78b54.png)

- 후

![image](https://user-images.githubusercontent.com/79133602/182199908-df7759c1-fb37-4b86-9a91-6924f2ce57ca.png)

