### PR TITLE
feat: Get MenuList API 적용

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,20 +1,23 @@
 import type { NextPage } from 'next'
-import { useState } from 'react'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
-import { MenuDummy, MenuListDummy } from '@constants/cardData'
 import MenuCardList from '@components/MenuCardList'
+import { useMenuList } from '@hooks/queries/useMenuList'
 
 const Home: NextPage = () => {
-  const [menuList, setMenuList] = useState(MenuListDummy)
+  const { menuList } = useMenuList()
+
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       observer.unobserve(entry.target)
-      setMenuList([...menuList, MenuDummy])
     },
     { threshold: 0.5 }
   )
 
-  return <MenuCardList menuList={menuList} divRef={ref} />
+  return (
+    <>
+      <MenuCardList menuList={menuList} divRef={ref} />
+    </>
+  )
 }
 
 export default Home

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -1,21 +1,20 @@
 import styled from '@emotion/styled'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
-import { MenuDummy, MenuListDummy } from '@constants/cardData'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
 import MenuCardList from '@components/MenuCardList'
 import SearchForm from '@components/SearchForm'
+import { useMenuList } from '@hooks/queries/useMenuList'
 
 const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
 
 const Search = () => {
   const router = useRouter()
   const { category } = router.query
-  const [menuList, setMenuList] = useState(MenuListDummy)
+  const { menuList } = useMenuList()
+
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       observer.unobserve(entry.target)
-      setMenuList([...menuList, MenuDummy])
     },
     { threshold: 0.5 }
   )

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -1,8 +1,8 @@
 import Avatar from '@components/Avatar'
 import MenuCardList from '@components/MenuCardList'
 import SearchForm from '@components/SearchForm'
-import { MenuDummy, MenuListDummy } from '@constants/cardData'
 import styled from '@emotion/styled'
+import { useMenuList } from '@hooks/queries/useMenuList'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { MouseEvent, useState } from 'react'
 
@@ -18,12 +18,10 @@ interface TabProps {
 
 const UserMenu = () => {
   const [option, setOption] = useState(SELECT_DUMMY[0])
-  const [menuList, setMenuList] = useState(MenuListDummy)
-
+  const { menuList } = useMenuList()
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       observer.unobserve(entry.target)
-      setMenuList([...menuList, MenuDummy])
     },
     { threshold: 0.5 }
   )

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -15,6 +15,7 @@ interface Props {
 }
 
 const IMAGE_ALT = 'NO IMAGE'
+const extensions = ['jpg', 'png', 'jpeg']
 
 const MenuCard = ({
   title,
@@ -25,6 +26,14 @@ const MenuCard = ({
   comments,
   divRef
 }: Props) => {
+  if (!imageUrl) imageUrl = 'https://via.placeholder.com/300x150'
+
+  if (imageUrl) {
+    if (!extensions.includes(imageUrl.split('.').slice(-1)[0])) {
+      imageUrl = 'https://via.placeholder.com/300x150'
+    }
+  }
+
   return (
     <CardContainer ref={divRef}>
       <Title>{title}</Title>

--- a/src/components/MenuCardList.tsx
+++ b/src/components/MenuCardList.tsx
@@ -1,5 +1,5 @@
 import { RefObject } from 'react'
-import { Menu } from '../types/index'
+import { Menu } from '@interfaces'
 import styled from '@emotion/styled'
 import Link from 'next/link'
 import MenuCard from '@components/MenuCard'
@@ -22,9 +22,9 @@ const MenuCardList = ({ menuList, divRef }: Props) => {
                   title={menu.title}
                   imageUrl={menu.image}
                   avatarImageUrl={menu.author.image}
-                  author={menu.author.nickname}
+                  author={menu.author.nickName}
                   likes={menu.likes}
-                  comments={menu.comments}
+                  comments={10}
                   divRef={menuList.length === idx + 1 ? divRef : null}
                 />
               </a>

--- a/src/hooks/queries/useMenuList.ts
+++ b/src/hooks/queries/useMenuList.ts
@@ -1,0 +1,15 @@
+import axios from '@lib/axios'
+import { Menu } from '@interfaces'
+import { useQuery } from '@tanstack/react-query'
+
+const getMenuList = async () => {
+  const { data } = await axios.get<Menu[]>(`/menu`)
+
+  return data
+}
+
+export const useMenuList = () => {
+  const { data, isLoading } = useQuery<Menu[], Error>(['menuList'], getMenuList)
+
+  return { menuList: data || [], isLoading }
+}


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #83

## 📌 기능 설명

메뉴 카드 리스트를 API를 통해 렌더링 적용했습니다.

## 👩‍💻 요구 사항과 구현 내용

- 중간 발표를 위해 우선 검색, 사용자 메뉴 등의 조건은 적용하지 않고 전체 메뉴만 조회하도록 되어 있습니다.

## 구현 결과
![tetetete](https://user-images.githubusercontent.com/81891292/182631655-f17abded-ad9e-4c92-8719-780d464b5853.PNG)

