### PR TITLE
feat: 메뉴 상세 페이지 API 적용

### DIFF
--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -1,15 +1,8 @@
-import React, { useState } from 'react'
 import MenuDetail from '@components/detail/MenuDetail'
 import CommentInput from '@components/detail/CommentInput'
 import CommentList from '@components/detail/CommentList'
 
 const Detail = () => {
-  const [user, setUser] = useState({
-    id: 111,
-    name: '계란이 조아',
-    profileImageUrl: 'https://via.placeholder.com/300x150'
-  })
-
   return (
     <>
       <MenuDetail />

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -1,12 +1,15 @@
-import Modal from '@components/Modal'
+import React, { useState } from 'react'
 import styled from '@emotion/styled'
-import React, { Fragment, useState } from 'react'
+import Modal from '@components/Modal'
+import { useMenu } from '@hooks/queries/useMenu'
+import { useRouter } from 'next/router'
 import { AiFillHeart, AiOutlineHeart } from 'react-icons/ai'
 import { BiDotsHorizontalRounded } from 'react-icons/bi'
-import menuDummy from './menuDummy.json'
 
 const MenuDetail = () => {
-  const [menu, setMenu] = useState(menuDummy)
+  const router = useRouter()
+  const id = parseInt(router.query.id as string, 10)
+  const { data: menu } = useMenu(id)
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   const handleEditMenuClick = (e: React.MouseEvent<SVGElement, MouseEvent>) => {
@@ -16,6 +19,8 @@ const MenuDetail = () => {
   const handleEditMenuClose = () => {
     setIsModalOpen(false)
   }
+
+  if (!menu) return <></>
 
   return (
     <MenuContainer>
@@ -33,31 +38,29 @@ const MenuDetail = () => {
       </Header>
 
       <ImageWrapper>
-        <Image src={menu.imageUrl} alt="" />
+        <Image src={menu.image} alt="" />
       </ImageWrapper>
 
       <Footer>
         <UserWrapper>
-          <Avatar src={menu.author.profileImageUrl} />
-          <UserNameText>{menu.author.name}</UserNameText>
+          <Avatar src={menu.author.image} />
+          <UserNameText>{menu.author.nickName}</UserNameText>
         </UserWrapper>
         <LikeWrapper>
-          <Heart size={30} />
+          <EmptyHeart size={30} />
           <LikesCountText>{menu.likes}</LikesCountText>
         </LikeWrapper>
       </Footer>
 
       <OptionsWrapper>
         <div>
-          <FranchiseText>[{menu.franchise}] </FranchiseText>
+          <FranchiseText>{menu.franchise.name} </FranchiseText>
           <span>{menu.originalTitle}</span>
         </div>
-        {menu.options.map((option) => (
-          <Fragment key={option.name}>
-            <OptionText>
-              + {option.name} {option.description}
-            </OptionText>
-          </Fragment>
+        {menu.optionList.map(({ optionName, optionDescription }) => (
+          <OptionText key={optionName}>
+            + {optionName} {optionDescription}
+          </OptionText>
         ))}
         <PriceText>예상 가격: {menu.expectedPrice} 원</PriceText>
       </OptionsWrapper>
@@ -172,11 +175,13 @@ const Heart = styled(AiFillHeart)`
   cursor: pointer;
 `
 
+const EmptyHeart = styled(AiOutlineHeart)`
+  cursor: pointer;
+`
+
 const LikesCountText = styled.span`
   font-size: 1.4rem;
   font-weight: 700;
 `
-
-const EmptyHeart = styled(AiOutlineHeart)``
 
 export default MenuDetail

--- a/src/hooks/mutations/useChangeImageMutation.ts
+++ b/src/hooks/mutations/useChangeImageMutation.ts
@@ -2,7 +2,7 @@ import axios from '@lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 interface Params {
-  userId: string
+  userId: number
   image: string
 }
 

--- a/src/hooks/mutations/useChangeNickNameMutation.ts
+++ b/src/hooks/mutations/useChangeNickNameMutation.ts
@@ -2,7 +2,7 @@ import axios from '@lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 interface Params {
-  userId: string
+  userId: number
   nickName: string
 }
 

--- a/src/hooks/mutations/useChangePasswordMutation.ts
+++ b/src/hooks/mutations/useChangePasswordMutation.ts
@@ -2,7 +2,7 @@ import axios from '@lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 interface Params {
-  userId: string
+  userId: number
   password: string
 }
 

--- a/src/hooks/mutations/useChangeSnsAccountMutation.ts
+++ b/src/hooks/mutations/useChangeSnsAccountMutation.ts
@@ -2,7 +2,7 @@ import axios from '@lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 interface Params {
-  userId: string
+  userId: number
   snsAccount: string
 }
 

--- a/src/hooks/queries/useCommentList.ts
+++ b/src/hooks/queries/useCommentList.ts
@@ -2,13 +2,13 @@ import axios from '@lib/axios'
 import { Comment } from '@interfaces'
 import { useQuery } from '@tanstack/react-query'
 
-const getCommentListByMenuId = async (menuId: string) => {
+const getCommentListByMenuId = async (menuId: number) => {
   const { data } = await axios.get<Comment[]>(`/menu/${menuId}/comments`)
 
   return data
 }
 
-export const useCommentList = (menuId: string) => {
+export const useCommentList = (menuId: number) => {
   return useQuery<Comment[], Error>(['comments', menuId], () =>
     getCommentListByMenuId(menuId)
   )

--- a/src/hooks/queries/useMenu.ts
+++ b/src/hooks/queries/useMenu.ts
@@ -9,5 +9,7 @@ const getMenuById = async (menuId: number) => {
 }
 
 export const useMenu = (menuId: number) => {
-  return useQuery<Menu, Error>(['menu', menuId], () => getMenuById(menuId))
+  return useQuery<Menu, Error>(['menu', menuId], () => getMenuById(menuId), {
+    enabled: !!menuId
+  })
 }

--- a/src/hooks/queries/useMenu.ts
+++ b/src/hooks/queries/useMenu.ts
@@ -2,12 +2,12 @@ import axios from '@lib/axios'
 import { Menu } from '@interfaces'
 import { useQuery } from '@tanstack/react-query'
 
-const getMenuById = async (menuId: string) => {
+const getMenuById = async (menuId: number) => {
   const { data } = await axios.get<Menu>(`/menu/${menuId}`)
 
   return data
 }
 
-export const useMenu = (menuId: string) => {
+export const useMenu = (menuId: number) => {
   return useQuery<Menu, Error>(['menu', menuId], () => getMenuById(menuId))
 }

--- a/src/hooks/queries/useMenuByUserId.ts
+++ b/src/hooks/queries/useMenuByUserId.ts
@@ -2,13 +2,13 @@ import axios from '@lib/axios'
 import { Menu } from '@interfaces'
 import { useQuery } from '@tanstack/react-query'
 
-const getMenuByUserId = async (userId: string) => {
+const getMenuByUserId = async (userId: number) => {
   const { data } = await axios.get<Menu>(`/accounts/${userId}/menu`)
 
   return data
 }
 
-export const useMenuByUserId = (userId: string) => {
+export const useMenuByUserId = (userId: number) => {
   return useQuery<Menu, Error>(['menuByUserId', userId], () =>
     getMenuByUserId(userId)
   )

--- a/src/hooks/queries/useUser.ts
+++ b/src/hooks/queries/useUser.ts
@@ -2,12 +2,12 @@ import axios from '@lib/axios'
 import { User } from '@interfaces'
 import { useQuery } from '@tanstack/react-query'
 
-const getUserById = async (userId: string) => {
+const getUserById = async (userId: number) => {
   const { data } = await axios.get<User>(`/accounts/${userId}`)
 
   return data
 }
 
-export const useUser = (userId: string) => {
+export const useUser = (userId: number) => {
   return useQuery<User, Error>(['user', userId], () => getUserById(userId))
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -16,7 +16,7 @@ export interface Menu {
   originalTitle: string
   author: User
   content: string
-  optionList: Option[]
+  optionList: Omit<Option, 'id'>[]
   expectedPrice: number
   tasteList: Taste[]
   likes: number
@@ -35,14 +35,14 @@ export interface Comment {
 
 export interface Option {
   id: number
-  name: string
-  description: string
+  optionName: string
+  optionDescription: string
 }
 
 export interface Franchise {
   id: number
   image: string
-  franchise: string
+  name: string
 }
 
 export interface Taste {


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #95 
## 📌 기능 설명
메뉴 상세 페이지에 메뉴 단건 조회 API를 연동했습니다.

## 👩‍💻 요구 사항과 구현 내용
- useRouter hook을 이용해 동적인 id를 가져오고, 이를 통해 useMenu hook을 쏴서 얻은 data를 menu라는 이름으로 뿌립니다.
- optionList의 필드명이 내려오는대로 interface를 수정했습니다.
- Menu의 optionList 필드를 Omit을 통해 id를 빼도록 수정했습니다.

## 구현 결과
<img width="1440" alt="스크린샷 2022-08-04 16 58 37" src="https://user-images.githubusercontent.com/81501723/182795202-03277d21-f949-43f4-8623-574ee5bf0299.png">

