### PR TITLE
refactor: MenuList 순서 Reverse

### DIFF
--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -23,7 +23,7 @@ import {
   PLACEHOLDER_OPTION_DESCRIPTION,
   PLACEHOLDER_EXPECTED_PRICE
 } from '@constants/menuConstant'
-import { useFranchises } from '@hooks/queries/useFranchises'
+//import { useFranchises } from '@hooks/queries/useFranchises'
 
 const CreateMenu = () => {
   // 필드 값

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -4,8 +4,7 @@ import { useRouter } from 'next/router'
 import MenuCardList from '@components/MenuCardList'
 import SearchForm from '@components/SearchForm'
 import { useMenuList } from '@hooks/queries/useMenuList'
-
-const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
+import { SORT_OPTIONS } from '@constants/searchOption'
 
 const Search = () => {
   const router = useRouter()

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -5,8 +5,8 @@ import styled from '@emotion/styled'
 import { useMenuList } from '@hooks/queries/useMenuList'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { MouseEvent, useState } from 'react'
+import { SORT_OPTIONS } from '@constants/searchOption'
 
-const SORT_OPTIONS = ['최신순', '좋아요순', '댓글순']
 const SELECT_DUMMY = ['작성한 메뉴', '좋아요한 메뉴']
 const SIZE_100_IMG_URL = 'https://via.placeholder.com/100'
 

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const IMAGE_ALT = 'NO IMAGE'
-const extensions = ['jpg', 'png', 'jpeg']
+const extensions = ['jpg', 'png', 'jpeg', 'jfif']
 
 const MenuCard = ({
   title,

--- a/src/components/MenuCardList.tsx
+++ b/src/components/MenuCardList.tsx
@@ -12,7 +12,7 @@ interface Props {
 const MenuCardList = ({ menuList, divRef }: Props) => {
   return (
     <Container>
-      {menuList.map((menu, idx) => {
+      {[...menuList].reverse().map((menu, idx) => {
         return (
           <MenuCardWrapper key={idx}>
             <Link href={`/detail/${menu.id}`}>

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -6,10 +6,14 @@ import useForm from '@hooks/useForm'
 import Modal from './Modal'
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
-import TagContainer from './TagContainer'
 
 interface Props {
-  sortOptions: string[]
+  sortOptions: SortOption[]
+}
+
+interface SortOption {
+  label: string
+  value: string
 }
 
 interface SearchInput {
@@ -35,18 +39,15 @@ const validate = ({ keyword }: SearchInput) => {
 const SearchForm = ({ sortOptions }: Props) => {
   const router = useRouter()
   const [modalVisible, setModalVisible] = useState(false)
-  const [selectedTagList, setSelectedTagList] = useState<Array<number>>([])
   const { values, errors, handleChange, handleSubmit } = useForm({
     initialValues: {
       keyword: ''
     },
     onSubmit: (values) => {
-      const res = {
-        keyword: values.keyword,
-        sort: router.query.sort,
-        tasteIdList: selectedTagList
+      return {
+        keywords: values.keyword,
+        sortOption: router.query.sort
       }
-      return res
     },
     validate
   })
@@ -83,20 +84,12 @@ const SearchForm = ({ sortOptions }: Props) => {
           <Text>필터</Text>
         </FilterWrapper>
         <Modal visible={modalVisible} onClose={handleModalClose}>
-          <TagContainer
-            selectedTasteIdList={selectedTagList}
-            backgroundColor="white"
-            gap={2}
-            tagHeight={3.3}
-            onChange={(newTagList) => {
-              setSelectedTagList([...newTagList])
-            }}
-          />
+          TEMP MODAL CHILD
         </Modal>
         <select onChange={handleSortOptionChange}>
           {sortOptions.map((option) => (
-            <option key={option} value={option}>
-              {option}
+            <option key={option.value} value={option.value}>
+              {option.label}
             </option>
           ))}
         </select>

--- a/src/constants/searchOption.ts
+++ b/src/constants/searchOption.ts
@@ -1,0 +1,5 @@
+export const SORT_OPTIONS = [
+  { label: '최신순', value: 'recent' },
+  { label: '좋아요순', value: 'like' },
+  { label: '댓글순', value: 'comments' }
+]


### PR DESCRIPTION
## ✅ 이슈 번호

reslove #96

## 📌 기능 설명

메뉴 리스트 순서를 임시로 reverse 해서 렌더링 하도록 구현했습니다.
추후 백엔드에서 정렬 옵션 API를 내려준 후 삭제 예정입니다.


