### PR TITLE
feat: 태그 컨테이너 api로 교체

### DIFF
--- a/src/components/TagContainer.tsx
+++ b/src/components/TagContainer.tsx
@@ -1,8 +1,9 @@
 import { Taste } from '@customTypes/index'
 import styled from '@emotion/styled'
 import Tag from './Tag'
-import { dummyTasteList as tasteList } from '@constants/dummyMenu'
+import { dummyTasteList } from '@constants/dummyMenu'
 import { useState } from 'react'
+import { useTasteList } from '@hooks/queries/useTasteList'
 
 const MAX_TAG = 4
 interface Props {
@@ -22,8 +23,9 @@ const TagContainer = ({
   height = 20,
   gap = 0.8,
   tagHeight = 3.2,
-  backgroundColor = '#d9d9d9'
+  backgroundColor = '#ffffff'
 }: Props) => {
+  const { data: tasteList } = useTasteList()
   const tagIdList = selectedTasteIdList
   const handleClickTag = (clickedTagId: number) => {
     let newTagList = tagIdList
@@ -43,7 +45,7 @@ const TagContainer = ({
       gap={gap}
       backgroundColor={backgroundColor}
     >
-      {tasteList.map((taste) => (
+      {tasteList?.map((taste) => (
         <Tag
           key={taste.id}
           id={taste.id}

--- a/src/hooks/queries/useTasteList.ts
+++ b/src/hooks/queries/useTasteList.ts
@@ -1,0 +1,14 @@
+import axios from '@lib/axios'
+import { Taste } from '@interfaces'
+import { useQuery } from '@tanstack/react-query'
+
+const getTasteList = async () => {
+  const { data } = await axios.get<Taste[]>(`/tastes`)
+  return data
+}
+
+export const useTasteList = () => {
+  return useQuery<Taste[], Error>(['tasteList'], getTasteList, {
+    staleTime: Infinity
+  })
+}


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명
resolve #102 
<!-- 기능을 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용
- 이미지 컨테이너에 api를 붙였습니다

useTasteList 훅을 만들었습니다.
franchiseList와 같이 캐싱 infinity 처리 했습니다.
태그 컨테이너에 붙이고, 배경을 흰색으로 처리했습니다. 
<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과

<!-- 이미지를 첨부해주세요. -->
<img width="450" alt="image" src="https://user-images.githubusercontent.com/75849590/182850361-4c582a3a-4442-4836-a5d8-8e22c5b93867.png">

db에 저장되어있는 결과값이 나옵니다.

