### PR TITLE
feat: useLoginMutation 구현 및 로그인 페이지 적용

### DIFF
--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -2,11 +2,13 @@ import styled from '@emotion/styled'
 import Input from '@components/Input'
 import {
   INPUT_EMAIL,
-  PLACEHOLDER_EMAIL,
   INPUT_PASSWORD,
+  PLACEHOLDER_EMAIL,
   PLACEHOLDER_PASSWORD,
   REGEX_PASSWORD,
-  REGEX_EMAIL
+  REGEX_EMAIL,
+  MESSAGE_PASSWORD,
+  ERROR_EMAIL
 } from '@constants/inputConstant'
 import React, { useState, useCallback } from 'react'
 import { BsEye } from 'react-icons/bs'
@@ -27,16 +29,16 @@ const LoginPage = () => {
   const [password, setPassword] = useState('')
   const [errors, setErrors] = useState<Errors>({})
   const [isTypePassword, setIsTypePassword] = useState(false)
-  const router = useRouter()
   const { mutate: postLogin } = useLoginMutation()
+  const router = useRouter()
 
   const handleLoginSubmit = async (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     e.preventDefault()
-    const LoginIsValid = password && email && emailIsValid && passwordIsValid
-    if (LoginIsValid) {
-      //postLogin({ email, password })
+    const isLoginValid = password && email && emailIsValid && passwordIsValid
+    if (isLoginValid) {
+      postLogin({ email, password })
       router.replace('/')
     }
   }
@@ -54,14 +56,14 @@ const LoginPage = () => {
         e.target.value = value.slice(0, 10)
       }
       if (!REGEX_PASSWORD.test(value)) {
-        newErrors.password = '8-10자 사이로 공백없이 입력해주세요'
+        newErrors.password = MESSAGE_PASSWORD
         setPasswordIsValid(false)
       }
       setPassword(e.target.value)
     }
     if (name === INPUT_EMAIL) {
       if (!REGEX_EMAIL.test(value)) {
-        newErrors.email = '이메일 형식으로 입력해주세요.'
+        newErrors.email = ERROR_EMAIL
         setEmailIsValid(false)
       }
       setEmail(e.target.value)
@@ -102,7 +104,7 @@ const LoginPage = () => {
         </ChangePasswordButton>
       </LoginForm>
       <SignupText>
-        회원가입하시겠어요? <Link href={`/signup`}>[이동]</Link>
+        회원가입하시겠어요? <Link href={'/signup'}>[이동]</Link>
       </SignupText>
     </LoginContainer>
   )

--- a/src/hooks/mutations/useLoginMutation.ts
+++ b/src/hooks/mutations/useLoginMutation.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useRecoilState } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 import { User } from '@interfaces'
+import { setLocalToken } from '@utils/localToken'
 
 interface Params {
   email: string
@@ -32,7 +33,8 @@ export const useLoginMutation = () => {
   const [user, setUser] = useRecoilState<User>(currentUser)
   return useMutation(postLogin, {
     onSuccess: (data) => {
-      setUser({ ...user, ...data })
+      setUser({ ...user, ...data.account })
+      setLocalToken(data.token)
     }
   })
 }


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #107

## 📌 기능 설명
- useLoginMutation 구현 및 로그인 페이지 적용

## 👩‍💻 요구 사항과 구현 내용
로그인 페이지에서 모든 유효성 검사 통과 후 useLoginMutation 사용해 로그인 후 메인페이지로 이동하게 했습니다.
![image](https://user-images.githubusercontent.com/79133602/182894838-ea708521-869c-4617-8898-8645fa1dc8ef.png)

- 로그인 시 useLoginMutation 의 mutate가 onSuccess라면 토큰을 localStorage에 저장하고, user 정보를 받아 currentUser recoilState에 넣어줍니다.

