### PR TITLE
feat: 이미지 업로더 형식 제한 추가

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -5,7 +5,7 @@ import { BsPlusLg } from 'react-icons/bs'
 
 const FILE_TYPE = 'image/gif, image/jpeg, image/png'
 const FILE_INPUT_NAME = 'image-input'
-const FILE_REGEX = /\.(jpg|jpeg|png)$/i
+const FILE_REGEX = /\.(jpg|jpeg|png|JPG|JPEG|PNG)$/i
 interface Props {
   size?: number
   shape?: 'square' | 'circle'
@@ -25,15 +25,16 @@ const ImageUploader = ({
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
 
-    if (file?.name.match(FILE_REGEX)) {
-      setIsError(false)
-      reader.readAsDataURL(file)
-      reader.onload = () => {
-        setImage(reader.result)
-        onChange(file)
-      }
-    } else {
+    if (!file?.name.match(FILE_REGEX)) {
       setIsError(true)
+      return
+    }
+
+    setIsError(false)
+    reader.readAsDataURL(file)
+    reader.onload = () => {
+      setImage(reader.result)
+      onChange(file)
     }
   }
 

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -5,6 +5,7 @@ import { BsPlusLg } from 'react-icons/bs'
 
 const FILE_TYPE = 'image/gif, image/jpeg, image/png'
 const FILE_INPUT_NAME = 'image-input'
+const FILE_REGEX = /\.(jpg|jpeg|png)$/i
 interface Props {
   size?: number
   shape?: 'square' | 'circle'
@@ -19,15 +20,20 @@ const ImageUploader = ({
   onChange
 }: Props) => {
   const [image, setImage] = useState<ImageType>(value)
+  const [isError, setIsError] = useState(false)
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
-    if (file) {
+
+    if (file?.name.match(FILE_REGEX)) {
+      setIsError(false)
       reader.readAsDataURL(file)
       reader.onload = () => {
         setImage(reader.result)
         onChange(file)
       }
+    } else {
+      setIsError(true)
     }
   }
 
@@ -41,6 +47,11 @@ const ImageUploader = ({
       >
         <StyledPlus selected={image ? true : false} />
       </ImageBox>
+      {isError ? (
+        <ErrorMessage>확장자는 jpg, png, jpeg 만 가능해요!</ErrorMessage>
+      ) : (
+        ''
+      )}
       <FileInput
         id={FILE_INPUT_NAME}
         type="file"
@@ -78,6 +89,11 @@ const StyledPlus = styled(BsPlusLg)<{ selected: boolean }>`
   width: 10rem;
   height: 10rem;
   visibility: ${({ selected }) => (selected ? 'hidden' : 'visible')};
+`
+
+const ErrorMessage = styled.div`
+  font-size: 1.4rem;
+  color: red;
 `
 
 const FileInput = styled.input`

--- a/src/lib/axios/index.ts
+++ b/src/lib/axios/index.ts
@@ -7,7 +7,7 @@ import {
 } from './interceptors'
 
 const axiosInstance = axios.create({
-  timeout: 5000,
+  timeout: 10000,
   baseURL: '/api',
   headers: { 'Content-Type': 'application/json' }
 })


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명

resolve #103 

<!-- 기능을 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용

<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->
- 정규식을 사용해서 jpg, png, jpeg 파일만 들어가게 했습니다.
## 구현 결과

<!-- 이미지를 첨부해주세요. -->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/75849590/182908266-9e3f2120-9a68-4fbe-8a5a-4badda31f77d.png">

- png 확장자를 넣었을 때 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/75849590/182908343-13bc73ce-e06b-4823-9203-4d2c4f1db888.png">

- jfif 확장자를 넣었을 때
- (에러 메시지와 함께 화면이 바뀌지 않음)

