### PR TITLE
feat: 메뉴 상세 페이지 댓글 API(comments) 적용, 디자인 개선

### DIFF
--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -1,13 +1,31 @@
 import MenuDetail from '@components/detail/MenuDetail'
 import CommentInput from '@components/detail/CommentInput'
 import CommentList from '@components/detail/CommentList'
+import { useRouter } from 'next/router'
+import { useMenu } from '@hooks/queries/useMenu'
+import { useRecoilState } from 'recoil'
+import { currentUser } from '@recoil/currentUser'
+import { useCommentList } from '@hooks/queries/useCommentList'
 
 const Detail = () => {
+  const router = useRouter()
+  const id = parseInt(router.query.id as string, 10)
+  const [user] = useRecoilState(currentUser)
+  const { data: menu, isSuccess: isMenuSuccess } = useMenu(id)
+  const { data: commentList, isSuccess: isCommentListSuccess } =
+    useCommentList(id)
+
   return (
     <>
-      <MenuDetail />
-      <CommentInput />
-      <CommentList />
+      {isMenuSuccess && (
+        <>
+          <MenuDetail menu={menu} />
+          <CommentInput menuId={menu.id} userId={user.id} />
+        </>
+      )}
+      {isCommentListSuccess && (
+        <CommentList user={user} commentList={commentList} />
+      )}
     </>
   )
 }

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { usePostCommentMutation } from '@hooks/mutations/usePostCommentMutation'
 import React, {
   ChangeEvent,
   useCallback,
@@ -10,10 +11,16 @@ import React, {
 const GUEST_INPUT_PLACEHOLDER = '로그인 후 작성해주세요(최대 80자).'
 const LOGGEDIN_INPUT_PLACEHOLDER = '댓글을 입력해주세요.'
 
-const CommentInput = () => {
+interface Props {
+  menuId: number
+  userId: number
+}
+
+const CommentInput = ({ menuId, userId }: Props) => {
   const [comment, setComment] = useState('')
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [isLoggedIn, setIsLoggedIn] = useState(true)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const { mutate: postComment } = usePostCommentMutation()
 
   useEffect(() => {
     if (textareaRef.current === null) {
@@ -35,7 +42,11 @@ const CommentInput = () => {
   }, [])
 
   const handleAddButtonClick = () => {
-    console.log(comment)
+    postComment({
+      userId,
+      menuId,
+      comment
+    })
   }
 
   return (

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -1,7 +1,7 @@
-import Modal from '@components/Modal'
-import styled from '@emotion/styled'
-import { Comment, User } from '@interfaces'
 import React, { Fragment, useState } from 'react'
+import styled from '@emotion/styled'
+import Modal from '@components/Modal'
+import { Comment, User } from '@interfaces'
 import { BiTrash } from 'react-icons/bi'
 
 interface Props {
@@ -20,19 +20,28 @@ const CommentList = ({ user, commentList }: Props) => {
     setIsDeleteModalOpen(false)
   }
 
+  const getDate = (createdAt: string) => {
+    const month = createdAt.slice(5, 7) + '월'
+    const day = createdAt.slice(8, 10) + '일'
+    return month + day
+  }
+
   return (
     <CommentListContainer>
       <CommnetCountText>댓글 {commentList.length} 개</CommnetCountText>
-      {commentList.map((comment) => (
-        <Fragment key={comment.id}>
+      {commentList.map(({ id, author, createdAt, comment }) => (
+        <Fragment key={id}>
           <CommentWrapper>
-            <Avatar src={comment.author.image} />
+            <Avatar src={author.image} />
             <CommentContainer>
-              <UserNameText>{comment.author.nickName}</UserNameText>
-              <Comment>
-                <CommentText>{comment.comment}</CommentText>
+              <CommentHeaderWrapper>
+                <UserNameText>{author.nickName}</UserNameText>
+                <DateText>{getDate(createdAt)}</DateText>
+              </CommentHeaderWrapper>
+              <CommentBox>
+                <CommentText>{comment}</CommentText>
                 <ButtonWrapper onClick={handleDeleteCommentClick}>
-                  {user.id === comment.author.id && (
+                  {user.id === author.id && (
                     <>
                       <DeleteButton size={20} />
                       <Modal
@@ -45,7 +54,7 @@ const CommentList = ({ user, commentList }: Props) => {
                     </>
                   )}
                 </ButtonWrapper>
-              </Comment>
+              </CommentBox>
             </CommentContainer>
           </CommentWrapper>
         </Fragment>
@@ -79,13 +88,21 @@ const CommentContainer = styled.div`
   width: 100%;
 `
 
+const CommentHeaderWrapper = styled(Flex)`
+  align-items: center;
+  margin-bottom: 0.4rem;
+`
+
 const UserNameText = styled.div`
   font-size: 1.2rem;
   font-weight: 700;
-  margin-bottom: 0.5rem;
 `
 
-const Comment = styled(Flex)`
+const DateText = styled.span`
+  margin-left: 1rem;
+`
+
+const CommentBox = styled(Flex)`
   justify-content: space-between;
   font-size: 1.4rem;
   min-width: 100%;

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -2,7 +2,8 @@ import React, { Fragment, useState } from 'react'
 import styled from '@emotion/styled'
 import Modal from '@components/Modal'
 import { Comment, User } from '@interfaces'
-import { BiTrash } from 'react-icons/bi'
+import { BiDotsHorizontalRounded, BiTrash } from 'react-icons/bi'
+import { getDate } from '@utils/getDate'
 
 interface Props {
   user: User
@@ -20,12 +21,6 @@ const CommentList = ({ user, commentList }: Props) => {
     setIsDeleteModalOpen(false)
   }
 
-  const getDate = (createdAt: string) => {
-    const month = createdAt.slice(5, 7) + '월'
-    const day = createdAt.slice(8, 10) + '일'
-    return month + day
-  }
-
   return (
     <CommentListContainer>
       <CommnetCountText>댓글 {commentList.length} 개</CommnetCountText>
@@ -34,26 +29,29 @@ const CommentList = ({ user, commentList }: Props) => {
           <CommentWrapper>
             <Avatar src={author.image} />
             <CommentContainer>
-              <CommentHeaderWrapper>
-                <UserNameText>{author.nickName}</UserNameText>
-                <DateText>{getDate(createdAt)}</DateText>
-              </CommentHeaderWrapper>
+              <CommentHeader>
+                <NameAndDateWrapper>
+                  <UserNameText>{author.nickName}</UserNameText>
+                  <DateText>{getDate(createdAt)}</DateText>
+                </NameAndDateWrapper>
+                {user.id === author.id && (
+                  <>
+                    <Dots size={20} onClick={handleDeleteCommentClick} />
+                    <Modal
+                      visible={isDeleteModalOpen}
+                      onClose={handleDeleteCommentClose}
+                      option="drawer"
+                    >
+                      <ModalItem>
+                        <BiTrash size={25} />
+                        삭제
+                      </ModalItem>
+                    </Modal>
+                  </>
+                )}
+              </CommentHeader>
               <CommentBox>
                 <CommentText>{comment}</CommentText>
-                <ButtonWrapper onClick={handleDeleteCommentClick}>
-                  {user.id === author.id && (
-                    <>
-                      <DeleteButton size={20} />
-                      <Modal
-                        visible={isDeleteModalOpen}
-                        onClose={handleDeleteCommentClose}
-                        option="drawer"
-                      >
-                        <ModalItem>삭제</ModalItem>
-                      </Modal>
-                    </>
-                  )}
-                </ButtonWrapper>
               </CommentBox>
             </CommentContainer>
           </CommentWrapper>
@@ -88,9 +86,13 @@ const CommentContainer = styled.div`
   width: 100%;
 `
 
-const CommentHeaderWrapper = styled(Flex)`
-  align-items: center;
+const CommentHeader = styled(Flex)`
+  justify-content: space-between;
   margin-bottom: 0.4rem;
+`
+
+const NameAndDateWrapper = styled(Flex)`
+  align-items: center;
 `
 
 const UserNameText = styled.div`
@@ -102,8 +104,13 @@ const DateText = styled.span`
   margin-left: 1rem;
 `
 
+const Dots = styled(BiDotsHorizontalRounded)`
+  justify-self: end;
+  cursor: pointer;
+`
+
 const CommentBox = styled(Flex)`
-  justify-content: space-between;
+  justify-content: space-evenly;
   font-size: 1.4rem;
   min-width: 100%;
   border-radius: 0.5rem;
@@ -114,12 +121,6 @@ const CommentBox = styled(Flex)`
 const CommentText = styled.div`
   padding-right: 2rem;
   width: 100%;
-`
-
-const ButtonWrapper = styled.div`
-  justify-self: flex-end;
-  margin-left: 0.5rem;
-  cursor: pointer;
 `
 
 const ModalItem = styled(Flex)`
@@ -133,7 +134,5 @@ const ModalItem = styled(Flex)`
     margin-top: 1rem;
   }
 `
-
-const DeleteButton = styled(BiTrash)``
 
 export default CommentList

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -1,21 +1,18 @@
 import Modal from '@components/Modal'
 import styled from '@emotion/styled'
+import { Comment, User } from '@interfaces'
 import React, { Fragment, useState } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import commentListDummy from './commentsDummy.json'
 
-const CommentList = () => {
-  const [user, setUser] = useState({
-    id: 111,
-    name: '계란이 조아',
-    profileImageUrl: 'https://via.placeholder.com/300x150'
-  })
-  const [commentList, setCommentList] = useState(commentListDummy)
+interface Props {
+  user: User
+  commentList: Comment[]
+}
+
+const CommentList = ({ user, commentList }: Props) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
-  const handleDeleteCommentClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
+  const handleDeleteCommentClick = () => {
     setIsDeleteModalOpen(true)
   }
 
@@ -29,9 +26,9 @@ const CommentList = () => {
       {commentList.map((comment) => (
         <Fragment key={comment.id}>
           <CommentWrapper>
-            <Avatar src={comment.author.profileImageUrl} />
+            <Avatar src={comment.author.image} />
             <CommentContainer>
-              <UserNameText>{comment.author.name}</UserNameText>
+              <UserNameText>{comment.author.nickName}</UserNameText>
               <Comment>
                 <CommentText>{comment.comment}</CommentText>
                 <ButtonWrapper onClick={handleDeleteCommentClick}>

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -1,26 +1,24 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import Modal from '@components/Modal'
-import { useMenu } from '@hooks/queries/useMenu'
-import { useRouter } from 'next/router'
 import { AiFillHeart, AiOutlineHeart } from 'react-icons/ai'
 import { BiDotsHorizontalRounded } from 'react-icons/bi'
+import { Menu } from '@interfaces'
 
-const MenuDetail = () => {
-  const router = useRouter()
-  const id = parseInt(router.query.id as string, 10)
-  const { data: menu } = useMenu(id)
+interface Props {
+  menu: Menu
+}
+
+const MenuDetail = ({ menu }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const handleEditMenuClick = (e: React.MouseEvent<SVGElement, MouseEvent>) => {
+  const handleEditMenuClick = () => {
     setIsModalOpen(true)
   }
 
   const handleEditMenuClose = () => {
     setIsModalOpen(false)
   }
-
-  if (!menu) return <></>
 
   return (
     <MenuContainer>

--- a/src/hooks/mutations/usePostCommentMutation.ts
+++ b/src/hooks/mutations/usePostCommentMutation.ts
@@ -1,0 +1,34 @@
+import axios from '@lib/axios'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface Params {
+  userId: number
+  menuId: number
+  comment: string
+}
+
+interface Data {
+  menuId: number
+  commentId: number
+  comment: string
+}
+
+const postComment = async ({ userId, menuId, comment }: Params) => {
+  const { data } = await axios.post<Data>(`/comments`, {
+    userId,
+    menuId,
+    comment
+  })
+
+  return data
+}
+
+export const usePostCommentMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation(postComment, {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries([`comments`, data.menuId])
+    }
+  })
+}

--- a/src/hooks/queries/useCommentList.ts
+++ b/src/hooks/queries/useCommentList.ts
@@ -9,7 +9,9 @@ const getCommentListByMenuId = async (menuId: number) => {
 }
 
 export const useCommentList = (menuId: number) => {
-  return useQuery<Comment[], Error>(['comments', menuId], () =>
-    getCommentListByMenuId(menuId)
+  return useQuery<Comment[], Error>(
+    ['comments', menuId],
+    () => getCommentListByMenuId(menuId),
+    { enabled: !!menuId }
   )
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -30,7 +30,6 @@ export interface Comment {
   author: User
   comment: string
   createdAt: string
-  updatedAt: string
 }
 
 export interface Option {

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -1,0 +1,14 @@
+export const getDate = (createdAt: string) => {
+  let month = createdAt.slice(5, 7) + '월'
+  let day = createdAt.slice(8, 10) + '일'
+
+  if (createdAt[5] === '0') {
+    month = createdAt[6] + '월'
+  }
+
+  if (createdAt[8] === '0') {
+    day = createdAt[9] + '일'
+  }
+
+  return month + ' ' + day
+}


### PR DESCRIPTION
## ✅ 이슈 번호
#112 
## 📌 기능 설명

제목:
메뉴 상세 페이지 댓글 API(comments) 적용


## 👩‍💻 요구 사항과 구현 내용
- 기능
  - 댓글 조회(GET)
  - 댓글 작성(POST)
  - 날짜 추가(getDate 함수 작성)

- 디자인
  - 기존 휴지통 아이콘을 ... 을 눌렀을 때 삭제 버튼이 뜨도록 수정했습니다.
  - 날짜는 댓글 작성 닉네임 오른쪽에 배치했습니다.

## 구현 결과
<img width="1440" alt="스크린샷 2022-08-05 19 13 48" src="https://user-images.githubusercontent.com/81501723/183056364-72050fed-102f-408d-b168-4d676e5bd00b.png">
<img width="1440" alt="스크린샷 2022-08-05 19 13 46" src="https://user-images.githubusercontent.com/81501723/183056342-2eafd791-f165-49e5-8444-8082fa1cfd27.png">

