### PR TITLE
feat: 프랜차이즈 컴포넌트 분리 / EditPage mutiation 작성

### DIFF
--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -6,7 +6,6 @@ import TagContainer from '@components/TagContainer'
 import ImageUploader from '@components/ImageUploader'
 import Button from '@components/Button'
 import { Option } from '@customTypes/index'
-import { dummyFranchiseList } from '@constants/dummyMenu'
 import { usePostMenu } from '@hooks/mutations/usePostMenuMutation'
 import {
   MIN_OPTION,
@@ -23,12 +22,12 @@ import {
   PLACEHOLDER_OPTION_DESCRIPTION,
   PLACEHOLDER_EXPECTED_PRICE
 } from '@constants/menuConstant'
-//import { useFranchises } from '@hooks/queries/useFranchises'
+import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 
 const CreateMenu = () => {
   // 필드 값
   const router = useRouter()
-
+  const { data: franchiseList } = useFranchiseList()
   const { mutate } = usePostMenu()
   const [file, setFile] = useState<File | null>(null)
   const [franchiseId, setFranchiseId] = useState(1)
@@ -174,7 +173,7 @@ const CreateMenu = () => {
       <ImageUploader onChange={handleImageChange} />
       <InputWrapper>
         <Select name={NAME_SELECT} onChange={handleFranchiseChange}>
-          {dummyFranchiseList.map((franchise) => (
+          {franchiseList?.map((franchise) => (
             <option key={franchise.id} value={franchise.id}>
               {franchise.name}
             </option>

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -8,7 +8,6 @@ import Button from '@components/Button'
 import FranchiseSelect from '@components/FranchiseSelect'
 import { Option } from '@customTypes/index'
 import { usePostMenu } from '@hooks/mutations/usePostMenuMutation'
-import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 import {
   MIN_OPTION,
   MAX_OPTION,
@@ -27,7 +26,6 @@ import {
 const CreateMenu = () => {
   // 필드 값
   const router = useRouter()
-  const { data: franchiseList } = useFranchiseList()
   const { mutate } = usePostMenu()
   const [file, setFile] = useState<File | null>(null)
   const [franchiseId, setFranchiseId] = useState(1)
@@ -272,11 +270,6 @@ const InputWrapper = styled.div`
 const Title = styled.h1`
   font-size: 4rem;
   align-self: start;
-`
-
-const Select = styled.select`
-  width: 100%;
-  height: 3.2rem;
 `
 
 const OptionName = styled(Input)`

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -5,12 +5,13 @@ import Input from '@components/Input'
 import TagContainer from '@components/TagContainer'
 import ImageUploader from '@components/ImageUploader'
 import Button from '@components/Button'
+import FranchiseSelect from '@components/FranchiseSelect'
 import { Option } from '@customTypes/index'
 import { usePostMenu } from '@hooks/mutations/usePostMenuMutation'
+import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 import {
   MIN_OPTION,
   MAX_OPTION,
-  NAME_SELECT,
   NAME_TITLE,
   NAME_ORIGINAL_TITLE,
   NAME_OPTION_NAME,
@@ -22,7 +23,6 @@ import {
   PLACEHOLDER_OPTION_DESCRIPTION,
   PLACEHOLDER_EXPECTED_PRICE
 } from '@constants/menuConstant'
-import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 
 const CreateMenu = () => {
   // 필드 값
@@ -172,13 +172,7 @@ const CreateMenu = () => {
       <Title>메뉴 생성</Title>
       <ImageUploader onChange={handleImageChange} />
       <InputWrapper>
-        <Select name={NAME_SELECT} onChange={handleFranchiseChange}>
-          {franchiseList?.map((franchise) => (
-            <option key={franchise.id} value={franchise.id}>
-              {franchise.name}
-            </option>
-          ))}
-        </Select>
+        <FranchiseSelect onChange={handleFranchiseChange} />
         <Input
           height={2.4}
           type="text"

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -32,7 +32,6 @@ const EditMenu = () => {
 
   const mutate = useChangeMenu()
   const { data: menuData } = useMenu(Number(id))
-  //onsole.log(menuData)
 
   useEffect(() => {
     if (menuData) {
@@ -275,11 +274,6 @@ const InputWrapper = styled.div`
 const Title = styled.h1`
   font-size: 4rem;
   align-self: start;
-`
-
-const Select = styled.select`
-  width: 100%;
-  height: 3.2rem;
 `
 
 const OptionName = styled(Input)`

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 import Input from '@components/Input'
+import FranchiseSelect from '@components/FranchiseSelect'
 import TagContainer from '@components/TagContainer'
 import ImageUploader from '@components/ImageUploader'
 import Button from '@components/Button'
-import { Option } from '@customTypes/index'
-import { dummyFranchiseList, dummyMenu } from '@constants/dummyMenu'
+import { Option } from '@interfaces'
+import { dummyMenu } from '@constants/dummyMenu'
+import { useMenu } from '@hooks/queries/useMenu'
+import { useChangeMenu } from '@hooks/mutations/useChangeMenuMutation'
 import {
   MIN_OPTION,
   MAX_OPTION,
-  NAME_SELECT,
   NAME_TITLE,
   NAME_ORIGINAL_TITLE,
   NAME_OPTION_NAME,
@@ -21,15 +23,31 @@ import {
   PLACEHOLDER_OPTION_DESCRIPTION,
   PLACEHOLDER_EXPECTED_PRICE
 } from '@constants/menuConstant'
+import { useRouter } from 'next/router'
 
 const EditMenu = () => {
   // 필드 값
-  const defaultImage = dummyMenu.image
+  const router = useRouter()
+  const { id } = router.query
+
+  const mutate = useChangeMenu()
+  const { data: menuData } = useMenu(Number(id))
+  //onsole.log(menuData)
+
+  useEffect(() => {
+    if (menuData) {
+      setFranchiseId(menuData.franchise.id)
+      setTitle(menuData.title)
+      setOriginalTitle(menuData.originalTitle)
+      setOptionList(menuData.optionList)
+      setExpectedPrice(menuData.expectedPrice)
+    }
+  }, [menuData])
   const [file, setFile] = useState<File | null>(null)
-  const [franchiseId, setFranchiseId] = useState(dummyMenu.franchise.id)
-  const [title, setTitle] = useState(dummyMenu.title)
+  const [franchiseId, setFranchiseId] = useState(0)
+  const [title, setTitle] = useState('')
   const [originalTitle, setOriginalTitle] = useState(dummyMenu.originalTitle)
-  const [optionList, setOptionList] = useState<Option[]>(dummyMenu.options)
+  const [optionList, setOptionList] = useState<Option[]>([])
   const [tasteIdList, setTasteIdList] = useState<number[]>(
     dummyMenu.tastes.map((taste) => taste.id)
   )
@@ -155,15 +173,9 @@ const EditMenu = () => {
   return (
     <FlexContainer>
       <Title>메뉴 수정</Title>
-      <ImageUploader onChange={handleImageChange} />
+      <ImageUploader value={menuData?.image} onChange={handleImageChange} />
       <InputWrapper>
-        <Select name={NAME_SELECT} onChange={handleFranchiseChange}>
-          {dummyFranchiseList.map((franchise) => (
-            <option key={franchise.id} value={franchise.id}>
-              {franchise.name}
-            </option>
-          ))}
-        </Select>
+        <FranchiseSelect onChange={handleFranchiseChange} />
         <Input
           height={2.4}
           type="text"

--- a/src/components/FranchiseSelect.tsx
+++ b/src/components/FranchiseSelect.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled'
+import { useFranchiseList } from '@hooks/queries/useFranchiseList'
+import { NAME_SELECT } from '@constants/menuConstant'
+
+interface Props {
+  onChange: (e: React.FormEvent<HTMLSelectElement>) => void
+}
+
+const FranchiseSelect = ({ onChange }: Props) => {
+  const { data: franchiseList } = useFranchiseList()
+
+  return (
+    <Select name={NAME_SELECT} onChange={onChange}>
+      {franchiseList?.map((franchise) => (
+        <option key={franchise.id} value={franchise.id}>
+          {franchise.name}
+        </option>
+      ))}
+    </Select>
+  )
+}
+
+const Select = styled.select`
+  width: 100%;
+  height: 4.8rem;
+  border-radius: 6px;
+`
+
+export default FranchiseSelect

--- a/src/components/FranchiseSelect.tsx
+++ b/src/components/FranchiseSelect.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const FranchiseSelect = ({ onChange }: Props) => {
-  const { data: franchiseList } = useFranchiseList()
+  const { franchiseList } = useFranchiseList()
 
   return (
     <Select name={NAME_SELECT} onChange={onChange}>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ImageType } from '@customTypes/index'
 import { BsPlusLg } from 'react-icons/bs'
 
@@ -21,6 +21,11 @@ const ImageUploader = ({
 }: Props) => {
   const [image, setImage] = useState<ImageType>(value)
   const [isError, setIsError] = useState(false)
+
+  useEffect(() => {
+    setImage(value)
+  }, [value])
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
@@ -29,7 +34,6 @@ const ImageUploader = ({
       setIsError(true)
       return
     }
-
     setIsError(false)
     reader.readAsDataURL(file)
     reader.onload = () => {

--- a/src/components/TagContainer.tsx
+++ b/src/components/TagContainer.tsx
@@ -25,7 +25,7 @@ const TagContainer = ({
   tagHeight = 3.2,
   backgroundColor = '#ffffff'
 }: Props) => {
-  const { data: tasteList } = useTasteList()
+  const { tasteList } = useTasteList()
   const tagIdList = selectedTasteIdList
   const handleClickTag = (clickedTagId: number) => {
     let newTagList = tagIdList

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -57,9 +57,9 @@ const MenuDetail = () => {
           <FranchiseText>{menu.franchise.name} </FranchiseText>
           <span>{menu.originalTitle}</span>
         </div>
-        {menu.optionList.map(({ optionName, optionDescription }) => (
-          <OptionText key={optionName}>
-            + {optionName} {optionDescription}
+        {menu.optionList.map(({ name, description }) => (
+          <OptionText key={name}>
+            + {name} {description}
           </OptionText>
         ))}
         <PriceText>예상 가격: {menu.expectedPrice} 원</PriceText>

--- a/src/hooks/mutations/useChangeMenuMutation.ts
+++ b/src/hooks/mutations/useChangeMenuMutation.ts
@@ -1,10 +1,6 @@
 import axios from '@lib/axios'
+import { Option } from '@interfaces'
 import { useMutation } from '@tanstack/react-query'
-
-interface Option {
-  name: string
-  description: string
-}
 
 interface Data {
   userId: number

--- a/src/hooks/mutations/useChangeMenuMutation.ts
+++ b/src/hooks/mutations/useChangeMenuMutation.ts
@@ -1,0 +1,44 @@
+import axios from '@lib/axios'
+import { useMutation } from '@tanstack/react-query'
+
+interface Option {
+  name: string
+  description: string
+}
+
+interface Data {
+  userId: number
+  franchiseId: number
+  title: string
+  content: string
+  originalTitle: string
+  expectedPrice: number
+  optionList: Option[]
+  tasteIdList: number[]
+}
+interface Params {
+  menuId: number
+  image: File | null
+  data: Data
+}
+
+export const patchMenu = async ({ menuId, image, data }: Params) => {
+  const formData = new FormData()
+  if (image) {
+    formData.append('image', image)
+  }
+  formData.append(
+    'data',
+    new Blob([JSON.stringify(data)], {
+      type: 'application/json'
+    })
+  )
+
+  await axios.post(`/menu${menuId}`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  })
+}
+
+export const useChangeMenu = () => {
+  return useMutation(patchMenu)
+}

--- a/src/hooks/mutations/usePostMenuMutation.ts
+++ b/src/hooks/mutations/usePostMenuMutation.ts
@@ -1,9 +1,6 @@
 import axios from '@lib/axios'
+import { Option } from '@interfaces'
 import { useMutation } from '@tanstack/react-query'
-interface Option {
-  name: string
-  description: string
-}
 
 interface Data {
   userId: number

--- a/src/hooks/queries/useFranchiseList.ts
+++ b/src/hooks/queries/useFranchiseList.ts
@@ -9,7 +9,12 @@ const getFranchiseList = async () => {
 }
 
 export const useFranchiseList = () => {
-  return useQuery<Franchise[], Error>(['franchises'], getFranchiseList, {
-    staleTime: Infinity
-  })
+  const { data, isLoading } = useQuery<Franchise[], Error>(
+    ['franchises'],
+    getFranchiseList,
+    {
+      staleTime: Infinity
+    }
+  )
+  return { franchiseList: data, isLoading }
 }

--- a/src/hooks/queries/useTasteList.ts
+++ b/src/hooks/queries/useTasteList.ts
@@ -8,7 +8,12 @@ const getTasteList = async () => {
 }
 
 export const useTasteList = () => {
-  return useQuery<Taste[], Error>(['tasteList'], getTasteList, {
-    staleTime: Infinity
-  })
+  const { data, isLoading } = useQuery<Taste[], Error>(
+    ['tasteList'],
+    getTasteList,
+    {
+      staleTime: Infinity
+    }
+  )
+  return { tasteList: data, isLoading }
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -16,7 +16,7 @@ export interface Menu {
   originalTitle: string
   author: User
   content: string
-  optionList: Omit<Option, 'id'>[]
+  optionList: Option[]
   expectedPrice: number
   tasteList: Taste[]
   likes: number
@@ -34,9 +34,8 @@ export interface Comment {
 }
 
 export interface Option {
-  id: number
-  optionName: string
-  optionDescription: string
+  name: string
+  description: string
 }
 
 export interface Franchise {


### PR DESCRIPTION
## ✅ 이슈 번호
 resolve #109

## 📌 기능 설명
### 이번에 작업할 때 제가 브랜치 분리를 못해서 양이 많습니다ㅠㅠ죄송합니다
### 다음부터는 꼭.. 분리하고 작업하겠습니다ㅠㅠ

- 프랜차이즈 api를 붙인 FranchiseSelect를 만들었습니다.
- Edit Page에 사용할 수정 mutaiton을 생성했습니다

<!-- 기능을 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용
- 프랜차이즈 api를 붙인 FranchiseSelect
Select 를 분리해서  컴포넌트 내에서 api를 불러오도록 했습니다.
따라서 props는 따로 받지 않고 onChange event Handler 만 받습니다. 


- Edit Page에 사용할 수정 mutaiton을 생성했습니다
edit Page 에 사용할 mutaition을 생성했습니다. 

<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과

<!-- 이미지를 첨부해주세요. -->
