### PR TITLE
feat: 나만의 메뉴 페이지 검색 API적용

### DIFF
--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -23,7 +23,12 @@ const Search = () => {
       <FixedWrapper>
         <InnerWrapper>
           <CategoryHeader>{category}</CategoryHeader>
-          <SearchForm sortOptions={SORT_OPTIONS} />
+          <SearchForm
+            sortOptions={SORT_OPTIONS}
+            onSubmit={() => {
+              return
+            }}
+          />
         </InnerWrapper>
       </FixedWrapper>
       <CardListWrapper>

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -6,6 +6,7 @@ import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { MouseEvent, useState } from 'react'
 import { SORT_OPTIONS } from '@constants/searchOption'
 import { useSearchMyMenuList } from '../../src/hooks/queries/useSearchMyMenuList'
+import { SearchFormOptions } from '@interfaces'
 
 const SELECT_DUMMY = ['작성한 메뉴', '좋아요한 메뉴']
 const SIZE_100_IMG_URL = 'https://via.placeholder.com/100'
@@ -17,12 +18,11 @@ interface TabProps {
 }
 
 const UserMenu = () => {
-  const { menuList } = useSearchMyMenuList(1, {
+  const [searchOptions, setSearchOptions] = useState({
     offset: 0,
-    limit: 10,
-    tasteList: []
+    limit: 10
   })
-
+  const { menuList } = useSearchMyMenuList(1, searchOptions)
   const [option, setOption] = useState(SELECT_DUMMY[0])
   const ref = useIntersectionObserver(
     async (entry, observer) => {
@@ -30,6 +30,10 @@ const UserMenu = () => {
     },
     { threshold: 0.5 }
   )
+
+  const handleSubmit = (values: SearchFormOptions) => {
+    setSearchOptions({ ...searchOptions, ...values })
+  }
 
   const handleClick = (e: MouseEvent<HTMLElement>) => {
     const divElement = e.target as HTMLElement
@@ -56,7 +60,7 @@ const UserMenu = () => {
               </Tab>
             ))}
           </TabContainer>
-          <SearchForm sortOptions={SORT_OPTIONS} />
+          <SearchForm sortOptions={SORT_OPTIONS} onSubmit={handleSubmit} />
         </InnerWrapper>
       </FixedWrapper>
       <CardListContainer>

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -2,7 +2,6 @@ import Avatar from '@components/Avatar'
 import MenuCardList from '@components/MenuCardList'
 import SearchForm from '@components/SearchForm'
 import styled from '@emotion/styled'
-import { useMenuList } from '@hooks/queries/useMenuList'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { MouseEvent, useState } from 'react'
 import { SORT_OPTIONS } from '@constants/searchOption'
@@ -18,15 +17,13 @@ interface TabProps {
 }
 
 const UserMenu = () => {
-  const { data } = useSearchMyMenuList(1, {
+  const { menuList } = useSearchMyMenuList(1, {
     offset: 0,
     limit: 10,
-    tasteList: [],
-    keyword: '민'
+    tasteList: []
   })
-  console.log(data)
+
   const [option, setOption] = useState(SELECT_DUMMY[0])
-  const { menuList } = useMenuList()
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       observer.unobserve(entry.target)

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -6,6 +6,7 @@ import { useMenuList } from '@hooks/queries/useMenuList'
 import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import { MouseEvent, useState } from 'react'
 import { SORT_OPTIONS } from '@constants/searchOption'
+import { useSearchMyMenuList } from '../../src/hooks/queries/useSearchMyMenuList'
 
 const SELECT_DUMMY = ['작성한 메뉴', '좋아요한 메뉴']
 const SIZE_100_IMG_URL = 'https://via.placeholder.com/100'
@@ -17,6 +18,13 @@ interface TabProps {
 }
 
 const UserMenu = () => {
+  const { data } = useSearchMyMenuList(1, {
+    offset: 0,
+    limit: 10,
+    tasteList: [],
+    keyword: '민'
+  })
+  console.log(data)
   const [option, setOption] = useState(SELECT_DUMMY[0])
   const { menuList } = useMenuList()
   const ref = useIntersectionObserver(

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -22,7 +22,7 @@ const PLACEHOLDER_SEARCH_INPUT = '메뉴 검색'
 
 const SearchForm = ({ sortOptions, onSubmit }: Props) => {
   const [modalVisible, setModalVisible] = useState(false)
-  const [tasteIdList, setTasteIdList] = useState<Array<number>>([])
+  const [tasteIdList, setTasteIdList] = useState<number[]>([])
   const [keyword, setKeyword] = useState('')
   const [sort, setSort] = useState('')
 

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -2,14 +2,15 @@ import styled from '@emotion/styled'
 import { BsFilterLeft } from 'react-icons/bs'
 import Input from '@components/Input'
 import { FiSearch } from 'react-icons/fi'
-import useForm from '@hooks/useForm'
 import Modal from './Modal'
-import { useState, ChangeEvent } from 'react'
-import { useRouter } from 'next/router'
+import { useState, ChangeEvent, FormEvent } from 'react'
 import TagContainer from './TagContainer'
+import { SearchFormOptions } from '@interfaces'
+import Button from './Button'
 
 interface Props {
   sortOptions: SortOption[]
+  onSubmit: (values: SearchFormOptions) => void
 }
 
 interface SortOption {
@@ -17,86 +18,63 @@ interface SortOption {
   value: string
 }
 
-interface SearchInput {
-  keyword: string
-}
-
-interface FormError {
-  length?: string
-}
-
 const PLACEHOLDER_SEARCH_INPUT = '메뉴 검색'
 
-const validate = ({ keyword }: SearchInput) => {
-  const result: FormError = {}
-
-  if (keyword.length < 2) {
-    result.length = '2글자 이상 입력해주세요!'
-  }
-
-  return result
-}
-
-const SearchForm = ({ sortOptions }: Props) => {
-  const router = useRouter()
+const SearchForm = ({ sortOptions, onSubmit }: Props) => {
   const [modalVisible, setModalVisible] = useState(false)
-  const [selectedTagList, setSelectedTagList] = useState<Array<number>>([])
-  const { values, errors, handleChange, handleSubmit } = useForm({
-    initialValues: {
-      keyword: ''
-    },
-    onSubmit: (values) => {
-      const result = {
-        keyword: values.keyword,
-        sort: router.query.sort,
-        tasteIdList: selectedTagList
-      }
-      return result
-    },
-    validate
-  })
+  const [tasteIdList, setTasteIdList] = useState<Array<number>>([])
+  const [keyword, setKeyword] = useState('')
+  const [sort, setSort] = useState('')
 
   const handleFilterClick = () => setModalVisible(true)
   const handleModalClose = () => setModalVisible(false)
 
   const handleSortOptionChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    router.replace({
-      pathname: router.pathname,
-      query: { ...router.query, sort: e.target.value }
-    })
+    setSort(e.target.value)
+    onSubmit({ keyword, tasteIdList, sort: e.target.value })
+  }
+
+  const handleKeywordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value)
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSubmit({ keyword, tasteIdList, sort })
+    console.log({ keyword, tasteIdList, sort })
   }
 
   return (
     <form onSubmit={handleSubmit}>
       <SearchWrapper>
         <SearchInput
-          name="keyword"
-          value={values.keyword}
+          value={keyword}
           height={5}
           type="text"
           placeholder={PLACEHOLDER_SEARCH_INPUT}
-          onChange={handleChange}
+          onChange={handleKeywordChange}
         />
         <SearchIcon />
       </SearchWrapper>
-      <ErrorMessage>
-        {Object.keys(errors).length > 0 && Object.values(errors)}
-      </ErrorMessage>
+      <ErrorMessage></ErrorMessage>
       <OptionContainer>
         <FilterWrapper onClick={handleFilterClick}>
           <FilterIcon />
           <Text>필터</Text>
         </FilterWrapper>
         <Modal visible={modalVisible} onClose={handleModalClose}>
-          <TagContainer
-            selectedTasteIdList={selectedTagList}
-            backgroundColor="white"
-            gap={2}
-            tagHeight={3.3}
-            onChange={(newTagList) => {
-              setSelectedTagList([...newTagList])
-            }}
-          />
+          <form onSubmit={handleSubmit}>
+            <TagContainer
+              selectedTasteIdList={tasteIdList}
+              backgroundColor="white"
+              gap={2}
+              tagHeight={3.3}
+              onChange={(newTagList) => {
+                setTasteIdList(newTagList)
+              }}
+            />
+            <Button onClick={handleModalClose}>제출</Button>
+          </form>
         </Modal>
         <select onChange={handleSortOptionChange}>
           {sortOptions.map((option) => (

--- a/src/constants/searchOption.ts
+++ b/src/constants/searchOption.ts
@@ -1,5 +1,5 @@
 export const SORT_OPTIONS = [
   { label: '최신순', value: 'recent' },
   { label: '좋아요순', value: 'like' },
-  { label: '댓글순', value: 'comments' }
+  { label: '댓글순', value: 'comment' }
 ]

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -1,0 +1,39 @@
+import { Menu } from '@interfaces'
+import axios from '@lib/axios'
+import { useQuery } from '@tanstack/react-query'
+
+interface Params {
+  keyword?: string
+  sort?: 'recent' | 'comment' | 'like'
+  tasteList: number[]
+  offset: number
+  limit: number
+}
+
+const getMyMenuList = async (accountId: number, params: Params) => {
+  const requestParameter = new URLSearchParams(
+    `?offset=${params.offset}&limit=${params.limit}&sort=recent`
+  )
+  if (params.keyword) {
+    requestParameter.set('keyword', params.keyword)
+  }
+  if (params.tasteList.length !== 0) {
+    requestParameter.set('tasteList', `${params.tasteList.join(',')}`)
+  }
+  if (params.sort) {
+    requestParameter.set('sort', `${params.sort}`)
+  }
+
+  console.log(requestParameter)
+
+  const { data } = await axios.get<Menu[]>(
+    `/accounts/${accountId}/menu?${requestParameter}`
+  )
+  return data
+}
+
+export const useSearchMyMenuList = (accountId: number, params: Params) => {
+  return useQuery<Menu[], Error>(['myMenuList', accountId], () =>
+    getMyMenuList(accountId, params)
+  )
+}

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -21,9 +21,9 @@ export const useSearchMyMenuList = (
   accountId: number,
   params: searchParams
 ) => {
-  const { keyword, tasteList, sort } = params
+  const { keyword, tasteIdList, sort, limit } = params
   const { data, isLoading, error } = useQuery<searchResponse, Error>(
-    ['myMenuList', accountId, keyword, tasteList, sort],
+    ['myMenuList', accountId, keyword, tasteIdList, sort, limit],
     () => getMyMenuList(accountId, params)
   )
 

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -1,39 +1,31 @@
 import { Menu } from '@interfaces'
 import axios from '@lib/axios'
 import { useQuery } from '@tanstack/react-query'
+import { createSearchRequestParameter } from '@utils/queryString'
+import { searchParams } from '@interfaces'
 
-interface Params {
-  keyword?: string
-  sort?: 'recent' | 'comment' | 'like'
-  tasteList: number[]
-  offset: number
-  limit: number
+interface searchResponse {
+  menu: Menu[]
 }
 
-const getMyMenuList = async (accountId: number, params: Params) => {
-  const requestParameter = new URLSearchParams(
-    `?offset=${params.offset}&limit=${params.limit}&sort=recent`
-  )
-  if (params.keyword) {
-    requestParameter.set('keyword', params.keyword)
-  }
-  if (params.tasteList.length !== 0) {
-    requestParameter.set('tasteList', `${params.tasteList.join(',')}`)
-  }
-  if (params.sort) {
-    requestParameter.set('sort', `${params.sort}`)
-  }
+const getMyMenuList = async (accountId: number, params: searchParams) => {
+  const requestParameter = createSearchRequestParameter(params)
 
-  console.log(requestParameter)
-
-  const { data } = await axios.get<Menu[]>(
+  const { data } = await axios.get<searchResponse>(
     `/accounts/${accountId}/menu?${requestParameter}`
   )
   return data
 }
 
-export const useSearchMyMenuList = (accountId: number, params: Params) => {
-  return useQuery<Menu[], Error>(['myMenuList', accountId], () =>
-    getMyMenuList(accountId, params)
+export const useSearchMyMenuList = (
+  accountId: number,
+  params: searchParams
+) => {
+  const { keyword, tasteList, sort } = params
+  const { data, isLoading, error } = useQuery<searchResponse, Error>(
+    ['myMenuList', accountId, keyword, tasteList, sort],
+    () => getMyMenuList(accountId, params)
   )
+
+  return { menuList: data?.menu || [], isLoading, error }
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -50,3 +50,11 @@ export interface Taste {
   name: string
   color: string
 }
+
+export interface searchParams {
+  keyword?: string
+  sort?: 'recent' | 'comment' | 'like'
+  tasteList: number[]
+  offset: number
+  limit: number
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -54,7 +54,13 @@ export interface Taste {
 export interface searchParams {
   keyword?: string
   sort?: 'recent' | 'comment' | 'like'
-  tasteList: number[]
+  tasteIdList?: number[]
   offset: number
   limit: number
+}
+
+export interface SearchFormOptions {
+  keyword: string
+  sort?: string
+  tasteIdList: number[]
 }

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -7,8 +7,9 @@ export const createSearchRequestParameter = (params: searchParams) => {
   if (params.keyword) {
     requestParameter.set('keyword', params.keyword)
   }
-  if (params.tasteList.length !== 0) {
-    requestParameter.set('tasteList', `${params.tasteList.join(',')}`)
+  if (params.tasteIdList && params.tasteIdList.length !== 0) {
+    console.log(params.tasteIdList)
+    requestParameter.set('tasteIdList', `${params.tasteIdList.join(',')}`)
   }
   if (params.sort) {
     requestParameter.set('sort', `${params.sort}`)

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -1,0 +1,17 @@
+import { searchParams } from '@interfaces'
+
+export const createSearchRequestParameter = (params: searchParams) => {
+  const requestParameter = new URLSearchParams(
+    `?offset=${params.offset}&limit=${params.limit}&sort=recent`
+  )
+  if (params.keyword) {
+    requestParameter.set('keyword', params.keyword)
+  }
+  if (params.tasteList.length !== 0) {
+    requestParameter.set('tasteList', `${params.tasteList.join(',')}`)
+  }
+  if (params.sort) {
+    requestParameter.set('sort', `${params.sort}`)
+  }
+  return requestParameter
+}


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #124 

## 📌 기능 설명

검색 조건 (키워드, 정렬, 맛 태그)에 따른 검색기능을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용

현재 정해진 API 요청 방식대로 요청은 정상적으로 작동되나 서버측 문제로 
- 댓글기준 정렬
- 맛 태그 검색
기능은 정상 동작하지 않습니다.

## 구현 결과

영상 촬영을 진행하려 했는데 메뉴가 싹 비워져서 찍지 못하고 있습니다..
