### PR TITLE
chore: Image 컴포넌트 src 외부 리소스 에러 해결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,10 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['user-images.githubusercontent.com']
+    domains: [
+      'user-images.githubusercontent.com',
+      'masiottae-image-bucket.s3.ap-northeast-2.amazonaws.com'
+    ]
   },
   async rewrites() {
     return [


### PR DESCRIPTION
## 📌 기능 설명

Image 컴포넌트 src 외부 리소스 에러 해결

## 👩‍💻 요구 사항과 구현 내용

현재  아래 도메인에서 이미지를 가져다 쓰고 있는데, Next js는 현재 도메인과 다른 곳의 리소스를 사용하면 에러가 난다고 합니다. 

- 'user-images.githubusercontent.com',
- 'masiottae-image-bucket.s3.ap-northeast-2.amazonaws.com'

그래서 next.config.js에 해당 도메인을 등록했습니다. 

![image](https://user-images.githubusercontent.com/79133602/183284312-399df0e0-e885-4d37-8d20-2420e4330dcf.png)
