### PR TITLE
feat: 메뉴 상세 페이지 최종 디자인 적용

### DIFF
--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -27,7 +27,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
       return
     }
 
-    textareaRef.current.style.height = '4rem'
+    textareaRef.current.style.height = '4.8rem'
     textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px'
 
     setComment(e.target.value)
@@ -45,7 +45,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
           setComment('')
           if (textareaRef.current) {
             textareaRef.current.value = ''
-            textareaRef.current.style.height = '4rem'
+            textareaRef.current.style.height = '4.8rem'
           }
         }
       }
@@ -79,10 +79,11 @@ const CommentWriteContainer = styled(Flex)`
 
 const Textarea = styled.textarea`
   width: 100%;
-  height: 4rem;
+  height: 4.8rem;
+  min-height: 4.8rem;
   font-size: 1.6rem;
   border-radius: 1rem;
-  padding: 1rem 7rem 1rem 1rem;
+  padding: 1.4rem 6rem 1rem 1rem;
   resize: none;
   overflow: hidden;
 
@@ -97,13 +98,13 @@ const Textarea = styled.textarea`
 
 const AddCommentButton = styled.button`
   position: absolute;
-  bottom: 0.4rem;
-  right: 0.4rem;
+  bottom: 0.6rem;
+  right: 0.6rem;
   width: 5rem;
-  height: 3.2rem;
+  height: 3.6rem;
   font-weight: 700;
   border: none;
-  border-radius: 0.6rem;
+  border-radius: 1rem;
   color: #f5f5f5;
   background-color: black;
   margin-left: -6rem;

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -58,7 +58,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
       }
     )
   }
-  console.log(textareaRef.current)
+
   return (
     <CommentWriteContainer>
       <Textarea
@@ -88,7 +88,6 @@ const Textarea = styled.textarea`
   width: 100%;
   height: 4rem;
   font-size: 1.6rem;
-  border: 0.1rem solid rgba(0, 0, 0, 0.4);
   border-radius: 1rem;
   padding: 1rem 7rem 1rem 1rem;
   resize: none;
@@ -99,16 +98,17 @@ const Textarea = styled.textarea`
   }
 
   &::placeholder {
-    font-size: 1.4rem;
+    font-size: 1.6rem;
   }
 `
 
 const AddCommentButton = styled.button`
   position: absolute;
-  bottom: 0.5rem;
-  right: 1rem;
+  bottom: 0.4rem;
+  right: 0.4rem;
   width: 5rem;
-  height: 3rem;
+  height: 3.2rem;
+  font-weight: 700;
   border: none;
   border-radius: 0.6rem;
   color: #f5f5f5;

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -42,13 +42,23 @@ const CommentInput = ({ menuId, userId }: Props) => {
   }, [])
 
   const handleAddButtonClick = () => {
-    postComment({
-      userId,
-      menuId,
-      comment
-    })
+    postComment(
+      {
+        userId,
+        menuId,
+        comment
+      },
+      {
+        onSuccess: () => {
+          setComment('')
+          if (textareaRef.current) {
+            textareaRef.current.value = ''
+          }
+        }
+      }
+    )
   }
-
+  console.log(textareaRef.current)
   return (
     <CommentWriteContainer>
       <Textarea

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -22,14 +22,6 @@ const CommentInput = ({ menuId, userId }: Props) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const { mutate: postComment } = usePostCommentMutation()
 
-  useEffect(() => {
-    if (textareaRef.current === null) {
-      return
-    }
-
-    textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px'
-  }, [])
-
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     if (textareaRef.current === null) {
       return
@@ -53,6 +45,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
           setComment('')
           if (textareaRef.current) {
             textareaRef.current.value = ''
+            textareaRef.current.style.height = '4rem'
           }
         }
       }

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -23,40 +23,42 @@ const CommentList = ({ user, commentList }: Props) => {
   }
 
   return (
-    <CommentListContainer>
-      <CommnetCountText>댓글 {commentList.length} 개</CommnetCountText>
-      {commentList.map(({ id, author, createdAt, comment }) => (
-        <Fragment key={id}>
-          <CommentWrapper>
-            <Avatar size={4} src={author.image} isLoading={false} />
-            <CommentContainer>
-              <CommentHeader>
-                <NameAndDateWrapper>
-                  <UserNameText>{author.nickName}</UserNameText>
-                  <DateText>{getDate(createdAt)}</DateText>
-                </NameAndDateWrapper>
-                {user.id === author.id && (
-                  <>
-                    <Dots size={20} onClick={handleDeleteCommentClick} />
-                    <Modal
-                      visible={isDeleteModalOpen}
-                      onClose={handleDeleteCommentClose}
-                      option="drawer"
-                    >
-                      <ModalItem>
-                        <BiTrash size={25} />
-                        삭제
-                      </ModalItem>
-                    </Modal>
-                  </>
-                )}
-              </CommentHeader>
-              <CommentText>{comment}</CommentText>
-            </CommentContainer>
-          </CommentWrapper>
-        </Fragment>
-      ))}
-    </CommentListContainer>
+    <>
+      <CommentListContainer>
+        <CommnetCountText>댓글 {commentList.length}개</CommnetCountText>
+        {commentList.map(({ id, author, createdAt, comment }) => (
+          <Fragment key={id}>
+            <CommentWrapper>
+              <Avatar size={4} src={author.image} isLoading={false} />
+              <CommentContainer>
+                <CommentHeader>
+                  <NameAndDateWrapper>
+                    <UserNameText>{author.nickName}</UserNameText>
+                    <DateText>{getDate(createdAt)}</DateText>
+                  </NameAndDateWrapper>
+                  {user.id === author.id && (
+                    <>
+                      <Dots size={20} onClick={handleDeleteCommentClick} />
+                    </>
+                  )}
+                </CommentHeader>
+                <CommentText>{comment}</CommentText>
+              </CommentContainer>
+            </CommentWrapper>
+          </Fragment>
+        ))}
+      </CommentListContainer>
+      <Modal
+        visible={isDeleteModalOpen}
+        onClose={handleDeleteCommentClose}
+        option="drawer"
+      >
+        <ModalItem>
+          <BiTrash size={25} />
+          삭제
+        </ModalItem>
+      </Modal>
+    </>
   )
 }
 
@@ -68,6 +70,7 @@ const CommentListContainer = styled.div``
 
 const CommnetCountText = styled.div`
   font-size: 1.4rem;
+  font-weight: 700;
   margin-bottom: 2rem;
 `
 
@@ -80,6 +83,7 @@ const CommentWrapper = styled(Flex)`
 const CommentContainer = styled.div`
   width: calc(100% - 4rem);
   margin-left: 1rem;
+  padding-bottom: 0.8rem;
 `
 
 const CommentHeader = styled(Flex)`

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -4,6 +4,7 @@ import Modal from '@components/Modal'
 import { Comment, User } from '@interfaces'
 import { BiDotsHorizontalRounded, BiTrash } from 'react-icons/bi'
 import { getDate } from '@utils/getDate'
+import Avatar from '@components/Avatar'
 
 interface Props {
   user: User
@@ -27,7 +28,7 @@ const CommentList = ({ user, commentList }: Props) => {
       {commentList.map(({ id, author, createdAt, comment }) => (
         <Fragment key={id}>
           <CommentWrapper>
-            <Avatar src={author.image} />
+            <Avatar size={4} src={author.image} isLoading={false} />
             <CommentContainer>
               <CommentHeader>
                 <NameAndDateWrapper>
@@ -50,9 +51,7 @@ const CommentList = ({ user, commentList }: Props) => {
                   </>
                 )}
               </CommentHeader>
-              <CommentBox>
-                <CommentText>{comment}</CommentText>
-              </CommentBox>
+              <CommentText>{comment}</CommentText>
             </CommentContainer>
           </CommentWrapper>
         </Fragment>
@@ -74,16 +73,13 @@ const CommnetCountText = styled.div`
 
 const CommentWrapper = styled(Flex)`
   margin-bottom: 1rem;
-`
-
-const Avatar = styled.img`
-  width: 3rem;
-  height: 3rem;
-  margin-right: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 0.1rem solid #f1f1f1;
 `
 
 const CommentContainer = styled.div`
-  width: 100%;
+  width: calc(100% - 4rem);
+  margin-left: 1rem;
 `
 
 const CommentHeader = styled(Flex)`
@@ -109,18 +105,8 @@ const Dots = styled(BiDotsHorizontalRounded)`
   cursor: pointer;
 `
 
-const CommentBox = styled(Flex)`
-  justify-content: space-evenly;
-  font-size: 1.4rem;
-  min-width: 100%;
-  border-radius: 0.5rem;
-  padding: 1rem;
-  background-color: rgba(0, 0, 0, 0.03);
-`
-
 const CommentText = styled.div`
-  padding-right: 2rem;
-  width: 100%;
+  font-size: 1.4rem;
 `
 
 const ModalItem = styled(Flex)`

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -27,12 +27,11 @@ const MenuDetail = ({ menu }: Props) => {
     setIsModalOpen(false)
   }
 
-  console.log(menu.tasteList)
   return (
     <>
       <MenuContainer>
         <ImageWrapper>
-          <Image src={menu.image} alt="" />
+          <Image src={menu.image} size={undefined} />
         </ImageWrapper>
 
         <HatWrapper>
@@ -109,9 +108,19 @@ const ImageWrapper = styled.div`
   margin: 0 -2rem;
 `
 
-const Image = styled.img`
-  width: 100%;
-  height: 100%;
+const Image = styled.label<{
+  size: number | undefined
+  src: string
+}>`
+  display: flex;
+  width: ${({ size }) => (size ? `${size}rem` : '100%')};
+  height: ${({ size }) => (size ? `${size}rem` : '100%')};
+  padding-top: ${({ size }) => (size ? `0` : '50%')};
+  padding-bottom: ${({ size }) => (size ? `0` : '50%')};
+  background-image: ${({ src }) => (src ? `url(${src})` : null)};
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 `
 
 const HatWrapper = styled.div`

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import Modal from '@components/Modal'
 import { AiFillHeart, AiOutlineHeart } from 'react-icons/ai'
-import { BiDotsHorizontalRounded } from 'react-icons/bi'
+import { BiDotsVerticalRounded, BiTrash } from 'react-icons/bi'
 import { Menu } from '@interfaces'
+import Avatar from '@components/Avatar'
+import { BsFillPencilFill } from 'react-icons/bs'
 
 interface Props {
   menu: Menu
@@ -11,6 +13,11 @@ interface Props {
 
 const MenuDetail = ({ menu }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isLikeClicked, setIsLikeClicked] = useState(true)
+
+  const handleLikeClick = () => {
+    setIsLikeClicked((prev) => !prev)
+  }
 
   const handleEditMenuClick = () => {
     setIsModalOpen(true)
@@ -20,48 +27,66 @@ const MenuDetail = ({ menu }: Props) => {
     setIsModalOpen(false)
   }
 
+  console.log(menu.tasteList)
   return (
     <MenuContainer>
-      <Header>
-        <Title>{menu.title}</Title>
-        <Dots size={30} onClick={handleEditMenuClick} />
-        <Modal
-          visible={isModalOpen}
-          onClose={handleEditMenuClose}
-          option="drawer"
-        >
-          <ModalItem>수정</ModalItem>
-          <ModalItem>삭제</ModalItem>
-        </Modal>
-      </Header>
+      <Image src={menu.image} alt="" />
 
-      <ImageWrapper>
-        <Image src={menu.image} alt="" />
-      </ImageWrapper>
+      <Hat />
+      <Header>
+        <LeftHeader>
+          <FranchiseText>{menu.franchise.name} </FranchiseText>
+          <Title>{menu.title}</Title>
+        </LeftHeader>
+        <RightHeader>
+          {isLikeClicked ? (
+            <Heart size={40} onClick={handleLikeClick} />
+          ) : (
+            <EmptyHeart size={40} onClick={handleLikeClick} />
+          )}
+          <LikesCountText clicked={isLikeClicked}>{menu.likes}</LikesCountText>
+          <Dots size={30} onClick={handleEditMenuClick} />
+          <Modal
+            visible={isModalOpen}
+            onClose={handleEditMenuClose}
+            option="drawer"
+          >
+            <ModalItem>
+              <BsFillPencilFill size={25} />
+              수정
+            </ModalItem>
+            <ModalItem>
+              <BiTrash size={25} />
+              삭제
+            </ModalItem>
+          </Modal>
+        </RightHeader>
+      </Header>
 
       <Footer>
         <UserWrapper>
-          <Avatar src={menu.author.image} />
+          <Avatar size={4} src={menu.author.image} isLoading={false} />
           <UserNameText>{menu.author.nickName}</UserNameText>
         </UserWrapper>
-        <LikeWrapper>
-          <EmptyHeart size={30} />
-          <LikesCountText>{menu.likes}</LikesCountText>
-        </LikeWrapper>
       </Footer>
 
       <OptionsWrapper>
-        <div>
-          <FranchiseText>{menu.franchise.name} </FranchiseText>
-          <span>{menu.originalTitle}</span>
-        </div>
+        <OriginalTitle>{menu.originalTitle}</OriginalTitle>
         {menu.optionList.map(({ name, description }) => (
           <OptionText key={name}>
-            + {name} {description}
+            {name} {description}
           </OptionText>
         ))}
-        <PriceText>예상 가격: {menu.expectedPrice} 원</PriceText>
+        <PriceText>{menu.expectedPrice} 원</PriceText>
       </OptionsWrapper>
+
+      <TagContainer>
+        {menu.tasteList.map(({ id, name, color }) => (
+          <Tag key={id} color={color}>
+            <span>{name}</span>
+          </Tag>
+        ))}
+      </TagContainer>
     </MenuContainer>
   )
 }
@@ -74,18 +99,67 @@ const MenuContainer = styled.div`
   margin-bottom: 2rem;
 `
 
+const Hat = styled.div`
+  position: relative;
+  top: -1.5rem;
+  background-color: white;
+  width: 100%;
+  height: 3rem;
+  border-radius: 1.5rem;
+`
+
 const Header = styled(Flex)`
   justify-content: space-between;
   align-items: center;
+  position: relative;
+
   margin-top: 1rem;
   margin-bottom: 2rem;
 `
 
-const Title = styled.span`
-  font-size: 3.6rem;
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
 `
 
-const Dots = styled(BiDotsHorizontalRounded)`
+const LeftHeader = styled.div``
+
+const FranchiseText = styled.div`
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #a3a3a3;
+  margin-bottom: 0.8rem;
+`
+
+const Title = styled.div`
+  font-size: 2.8rem;
+  font-weight: 700;
+`
+
+const RightHeader = styled(Flex)`
+  align-items: center;
+  position: relative;
+  top: -1.6rem;
+`
+
+const EmptyHeart = styled(AiOutlineHeart)`
+  cursor: pointer;
+`
+
+const Heart = styled(AiFillHeart)`
+  color: red;
+  cursor: pointer;
+`
+
+const LikesCountText = styled.span<{ clicked: boolean }>`
+  color: ${({ clicked }) => (clicked ? 'white' : 'black')};
+  position: relative;
+  right: 2.5rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+`
+
+const Dots = styled(BiDotsVerticalRounded)`
   cursor: pointer;
 `
 
@@ -101,14 +175,6 @@ const ModalItem = styled(Flex)`
   }
 `
 
-const ImageWrapper = styled(Flex)`
-  justify-content: center;
-  max-width: 50rem;
-  height: 100vw;
-  max-height: 50rem;
-  margin-bottom: -45%;
-`
-
 const Footer = styled(Flex)`
   justify-content: space-between;
   margin-bottom: 2rem;
@@ -119,8 +185,6 @@ const OptionsWrapper = styled(Flex)`
   font-size: 2rem;
   margin-bottom: 1rem;
   padding: 1rem;
-  border: 0.1rem solid rgba(0, 0, 0, 0.4);
-  border-radius: 1rem;
 
   & > div:first-of-type {
     margin-bottom: 2rem;
@@ -131,7 +195,8 @@ const OptionsWrapper = styled(Flex)`
   }
 `
 
-const FranchiseText = styled.span`
+const OriginalTitle = styled.div`
+  font-size: 1.6rem;
   font-weight: 700;
 `
 
@@ -141,18 +206,8 @@ const OptionText = styled.span`
 
 const PriceText = styled.span`
   font-size: 1.6rem;
+  font-weight: 700;
   align-self: flex-end;
-`
-
-const Image = styled.img`
-  width: 50%;
-  height: 50%;
-`
-
-const Avatar = styled.img`
-  width: 3rem;
-  height: 3rem;
-  margin-right: 1rem;
 `
 
 const UserWrapper = styled(Flex)`
@@ -162,24 +217,24 @@ const UserWrapper = styled(Flex)`
 const UserNameText = styled.div`
   font-size: 2rem;
   font-weight: 700;
+  margin-left: 1.2rem;
 `
 
-const LikeWrapper = styled(Flex)`
+const TagContainer = styled(Flex)`
+  gap: 1rem;
+`
+
+const Tag = styled(Flex)<{ color: string }>`
+  display: flex;
   align-items: center;
-`
-
-const Heart = styled(AiFillHeart)`
-  color: red;
-  cursor: pointer;
-`
-
-const EmptyHeart = styled(AiOutlineHeart)`
-  cursor: pointer;
-`
-
-const LikesCountText = styled.span`
-  font-size: 1.4rem;
+  color: white;
+  font-size: 1.8rem;
   font-weight: 700;
+  background-color: ${({ color }) => color};
+  min-width: fit-content;
+  height: 3.2rem;
+  padding: 1rem 2rem;
+  border-radius: 1.6rem;
 `
 
 export default MenuDetail

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -29,65 +29,71 @@ const MenuDetail = ({ menu }: Props) => {
 
   console.log(menu.tasteList)
   return (
-    <MenuContainer>
-      <Image src={menu.image} alt="" />
+    <>
+      <MenuContainer>
+        <ImageWrapper>
+          <Image src={menu.image} alt="" />
+        </ImageWrapper>
 
-      <Hat />
-      <Header>
-        <LeftHeader>
-          <FranchiseText>{menu.franchise.name} </FranchiseText>
-          <Title>{menu.title}</Title>
-        </LeftHeader>
-        <RightHeader>
-          {isLikeClicked ? (
-            <Heart size={40} onClick={handleLikeClick} />
-          ) : (
-            <EmptyHeart size={40} onClick={handleLikeClick} />
-          )}
-          <LikesCountText clicked={isLikeClicked}>{menu.likes}</LikesCountText>
-          <Dots size={30} onClick={handleEditMenuClick} />
-          <Modal
-            visible={isModalOpen}
-            onClose={handleEditMenuClose}
-            option="drawer"
-          >
-            <ModalItem>
-              <BsFillPencilFill size={25} />
-              수정
-            </ModalItem>
-            <ModalItem>
-              <BiTrash size={25} />
-              삭제
-            </ModalItem>
-          </Modal>
-        </RightHeader>
-      </Header>
+        <HatWrapper>
+          <Hat />
+        </HatWrapper>
+        <Header>
+          <LeftHeader>
+            <FranchiseText>{menu.franchise.name} </FranchiseText>
+            <Title>{menu.title}</Title>
+          </LeftHeader>
+          <RightHeader>
+            {isLikeClicked ? (
+              <Heart size={40} onClick={handleLikeClick} />
+            ) : (
+              <EmptyHeart size={40} onClick={handleLikeClick} />
+            )}
+            <LikesCountText clicked={isLikeClicked}>
+              {menu.likes}
+            </LikesCountText>
+            <Dots size={30} onClick={handleEditMenuClick} />
+          </RightHeader>
+        </Header>
 
-      <Footer>
         <UserWrapper>
           <Avatar size={4} src={menu.author.image} isLoading={false} />
           <UserNameText>{menu.author.nickName}</UserNameText>
         </UserWrapper>
-      </Footer>
 
-      <OptionsWrapper>
-        <OriginalTitle>{menu.originalTitle}</OriginalTitle>
-        {menu.optionList.map(({ name, description }) => (
-          <OptionText key={name}>
-            {name} {description}
-          </OptionText>
-        ))}
-        <PriceText>{menu.expectedPrice} 원</PriceText>
-      </OptionsWrapper>
+        <OptionsWrapper>
+          <OriginalTitle>{menu.originalTitle}</OriginalTitle>
+          {menu.optionList.map(({ name, description }) => (
+            <OptionText key={name}>
+              {name} {description}
+            </OptionText>
+          ))}
+          <PriceText>{menu.expectedPrice} 원</PriceText>
+        </OptionsWrapper>
 
-      <TagContainer>
-        {menu.tasteList.map(({ id, name, color }) => (
-          <Tag key={id} color={color}>
-            <span>{name}</span>
-          </Tag>
-        ))}
-      </TagContainer>
-    </MenuContainer>
+        <TagContainer>
+          {menu.tasteList.map(({ id, name, color }) => (
+            <Tag key={id} color={color}>
+              <span>{name}</span>
+            </Tag>
+          ))}
+        </TagContainer>
+      </MenuContainer>
+      <Modal
+        visible={isModalOpen}
+        onClose={handleEditMenuClose}
+        option="drawer"
+      >
+        <ModalItem>
+          <BsFillPencilFill size={25} />
+          수정
+        </ModalItem>
+        <ModalItem>
+          <BiTrash size={25} />
+          삭제
+        </ModalItem>
+      </Modal>
+    </>
   )
 }
 
@@ -97,6 +103,19 @@ const Flex = styled.div`
 
 const MenuContainer = styled.div`
   margin-bottom: 2rem;
+`
+
+const ImageWrapper = styled.div`
+  margin: 0 -2rem;
+`
+
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
+`
+
+const HatWrapper = styled.div`
+  margin: 0 -2rem;
 `
 
 const Hat = styled.div`
@@ -112,14 +131,8 @@ const Header = styled(Flex)`
   justify-content: space-between;
   align-items: center;
   position: relative;
-
-  margin-top: 1rem;
+  margin-top: -1.5rem;
   margin-bottom: 2rem;
-`
-
-const Image = styled.img`
-  width: 100%;
-  height: 100%;
 `
 
 const LeftHeader = styled.div``
@@ -139,14 +152,17 @@ const Title = styled.div`
 const RightHeader = styled(Flex)`
   align-items: center;
   position: relative;
-  top: -1.6rem;
+  top: -2rem;
+  left: 1rem;
 `
 
 const EmptyHeart = styled(AiOutlineHeart)`
+  margin-right: -1rem;
   cursor: pointer;
 `
 
 const Heart = styled(AiFillHeart)`
+  margin-right: -1rem;
   color: red;
   cursor: pointer;
 `
@@ -154,7 +170,7 @@ const Heart = styled(AiFillHeart)`
 const LikesCountText = styled.span<{ clicked: boolean }>`
   color: ${({ clicked }) => (clicked ? 'white' : 'black')};
   position: relative;
-  right: 2.5rem;
+  right: 1.5rem;
   font-size: 1.4rem;
   font-weight: 700;
 `
@@ -212,6 +228,7 @@ const PriceText = styled.span`
 
 const UserWrapper = styled(Flex)`
   align-items: center;
+  margin-bottom: 1rem;
 `
 
 const UserNameText = styled.div`

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -1,14 +1,6 @@
 export const getDate = (createdAt: string) => {
-  let month = createdAt.slice(5, 7) + '월'
-  let day = createdAt.slice(8, 10) + '일'
-
-  if (createdAt[5] === '0') {
-    month = createdAt[6] + '월'
-  }
-
-  if (createdAt[8] === '0') {
-    day = createdAt[9] + '일'
-  }
+  const month = Number(createdAt.slice(5, 7)) + '월'
+  const day = Number(createdAt.slice(8, 10)) + '일'
 
   return month + ' ' + day
 }


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #133 
## 📌 기능 설명
메뉴 상세 페이지 최종 디자인 적용

## 👩‍💻 요구 사항과 구현 내용
- 피그마에는 이미지와 그 아래 컨테이너가 화면에 꽉차도록 그려져있는데.. 기본 레이아웃 흐름에 맞춰서 좌우 padding을 갖고 있어서 해결이 안되어 패딩이 있는 상태로 적용했습니다.
- 맛 태그들은 일단 기존의 Tag 컴포넌트와 동작이 다른 것이 있어서 스타일을 유사하게 직접 만들어 넣어뒀습니다.
- Input을 4.8rem 혹은 5.6rem으로 설계해주셨는데, 위아래 padding 계산과 안의 content의 가운데 정렬이 힘들어 일단 4rem으로 만들었는데, 바꿔야할 것 같다면 의견 주시면 감사하겠습니다.
## 구현 결과

<!-- 이미지를 첨부해주세요. -->
<img width="1440" alt="스크린샷 2022-08-07 21 42 26" src="https://user-images.githubusercontent.com/81501723/183291189-5768af5e-a441-483a-b0f3-7117ac50f6fd.png">
<img width="1440" alt="스크린샷 2022-08-07 21 42 22" src="https://user-images.githubusercontent.com/81501723/183291193-4be1eb24-6105-4475-917f-ae0fdf7ca55c.png">

## 리뷰 반영 구현 결과
<img width="1440" alt="스크린샷 2022-08-08 10 54 31" src="https://user-images.githubusercontent.com/81501723/183323221-c3fd02a1-6250-4c6b-9295-7db2eae2ddc7.png">
<img width="1440" alt="스크린샷 2022-08-08 10 54 26" src="https://user-images.githubusercontent.com/81501723/183323236-a30dfdaf-27dd-4769-b2d0-df410b6c6613.png">

