### PR TITLE
refactor: 로그인 시 router 되도록 변경

### DIFF
--- a/src/hooks/mutations/useLoginMutation.ts
+++ b/src/hooks/mutations/useLoginMutation.ts
@@ -4,6 +4,7 @@ import { useRecoilState } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 import { User } from '@interfaces'
 import { setLocalToken } from '@utils/localToken'
+import { useRouter } from 'next/router'
 
 interface Params {
   email: string
@@ -30,11 +31,13 @@ const postLogin = async ({ email, password }: Params) => {
 }
 
 export const useLoginMutation = () => {
+  const router = useRouter()
   const [user, setUser] = useRecoilState<User>(currentUser)
   return useMutation(postLogin, {
     onSuccess: (data) => {
       setUser({ ...user, ...data.account })
       setLocalToken(data.token)
+      router.replace('/')
     }
   })
 }

--- a/src/hooks/mutations/useSignupMutation.ts
+++ b/src/hooks/mutations/useSignupMutation.ts
@@ -1,6 +1,5 @@
 import axios from '@lib/axios'
 import { useMutation } from '@tanstack/react-query'
-import { useRouter } from 'next/router'
 import { useLoginMutation } from '@hooks/mutations/useLoginMutation'
 
 interface Params {
@@ -52,11 +51,9 @@ const postSignup = async ({
 
 export const useSignupMutation = () => {
   const { mutate: postLogin } = useLoginMutation()
-  const router = useRouter()
   return useMutation(postSignup, {
     onSuccess: ({ email, password }) => {
       postLogin({ email, password })
-      router.replace('/')
     }
   })
 }


### PR DESCRIPTION
## 📌 기능 설명

- 로그인 시 router.replace('/) 되도록 변경

## 👩‍💻 요구 사항과 구현 내용

- 현재 회원가입 시 user 정보가 오지 않아서 자동 로그인을 위해 회원가입 onSuccess시 로그인을 하도록 함, 
- 각 페이지에서 onSubmit시 router.replace하기 보다 useLoginMutaion onSuccess시 라우팅하는 게 적합하다고 판단
- 로그인 페이지에서 mutation error가 나면, `존재하지 않는 회원입니다.`를 출력할 예정


