### PR TITLE
fix: 회원가입 오류 메시지 에러 해결

### DIFF
--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -127,9 +127,9 @@ const Signup = () => {
 
   const handleSignUpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value, name } = e.target
-    setErrors(initialValues)
 
     if (name === INPUT_EMAIL) {
+      setErrors({ ...errors, [name]: '' })
       if (!REGEX_EMAIL.test(value)) {
         setErrors({ ...errors, [name]: ERROR_EMAIL })
       }
@@ -138,6 +138,7 @@ const Signup = () => {
     }
 
     if (name === INPUT_NICKNAME) {
+      setErrors({ ...errors, [name]: '' })
       e.target.value = value.replace(/\s/, '').slice(0, MAX_NICKNAME)
 
       if (!REGEX_NICKNAME.test(value)) {
@@ -148,6 +149,7 @@ const Signup = () => {
     }
 
     if (name === INPUT_PASSWORD) {
+      setErrors({ ...errors, [name]: '' })
       e.target.value = value.replace(/\s/, '').slice(0, MAX_PASSWORD)
 
       if (!REGEX_PASSWORD.test(value)) {
@@ -156,6 +158,7 @@ const Signup = () => {
     }
 
     if (name === INPUT_PASSWORD_CONFIRM) {
+      setErrors({ ...errors, [name]: '' })
       e.target.value = value.replace(/\s/, '').slice(0, MAX_PASSWORD)
 
       if (!REGEX_PASSWORD.test(value)) {


### PR DESCRIPTION
## 📌 기능 설명

유효성 검사 시 다른 input을 작성하면 기존 에러메시지가 사라지는 버그 해결 

## 👩‍💻 요구 사항과 구현 내용

이메일 에러 후 비밀번호 에러, 확인 입력, 다시 비밀번호 입력 시 기존의 에러가 여전히 존재하는 것을 확인했습니다.

## 구현 결과

![image](https://user-images.githubusercontent.com/79133602/183376016-980b52b3-36bf-4cab-9f0c-7155076ca770.png)
