### PR TITLE
refactor: 내정보 페이지 보완

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.4.0",
-        "recoil": "^0.7.4"
+        "recoil": "^0.7.4",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/node": "18.0.6",
         "@types/react": "18.0.15",
         "@types/react-dom": "18.0.6",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
         "@typescript-eslint/parser": "^5.30.7",
         "eslint": "8.20.0",
@@ -1087,6 +1089,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.7",
@@ -4950,6 +4958,14 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -5804,6 +5820,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.7",
@@ -8377,6 +8399,11 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
       "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
       "requires": {}
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.4.0",
-    "recoil": "^0.7.4"
+    "recoil": "^0.7.4",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/node": "18.0.6",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "eslint": "8.20.0",

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -8,7 +8,6 @@ import InputMessage from '@components/InputMessage'
 import axios from '@lib/axios'
 import {
   TEXT,
-  PASSWORD,
   INPUT_EMAIL,
   INPUT_NICKNAME,
   INPUT_PASSWORD,

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -18,15 +18,11 @@ const ImageUploader = ({
   size,
   shape = 'square',
   value = null,
-  isReset,
+  isReset = true,
   onChange
 }: Props) => {
   const [image, setImage] = useState<ImageType>(value)
   const [isError, setIsError] = useState(false)
-
-  useEffect(() => {
-    setImage(value)
-  }, [value])
 
   useEffect(() => {
     isReset && setImage(value)

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -10,6 +10,7 @@ interface Props {
   size?: number
   shape?: 'square' | 'circle'
   value?: string | null
+  isReset?: boolean
   onChange: (file: File) => void
 }
 
@@ -17,6 +18,7 @@ const ImageUploader = ({
   size,
   shape = 'square',
   value = null,
+  isReset,
   onChange
 }: Props) => {
   const [image, setImage] = useState<ImageType>(value)
@@ -26,10 +28,13 @@ const ImageUploader = ({
     setImage(value)
   }, [value])
 
+  useEffect(() => {
+    isReset && setImage(value)
+  }, [isReset, value])
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
-
     if (!file?.name.match(FILE_REGEX)) {
       setIsError(true)
       return

--- a/src/components/myInfo/UserProfile.tsx
+++ b/src/components/myInfo/UserProfile.tsx
@@ -9,17 +9,17 @@ import { currentUser } from '@recoil/currentUser'
 import { User } from '@interfaces'
 import Image from 'next/image'
 import Modal from '@components/Modal'
+import axios from '@lib/axios'
 import ImageUploader from '@components/ImageUploader'
 import {
   MESSAGE_NICKNAME,
-  ERROR_EXIST_NICKNAME,
-  REGEX_NICKNAME
+  REGEX_NICKNAME,
+  PLACEHOLDER_NICKNAME,
+  INPUT_NICKNAME
 } from '@constants/inputConstant'
 import { useChangeImageMutation } from '@hooks/mutations/useChangeImageMutation'
 import { useChangeNickNameMutation } from '@hooks/mutations/useChangeNickNameMutation'
 import InputMessage from '@components/InputMessage'
-
-const CHANGE_NICKNAME_PLACEHOLDER = '변경할 닉네임'
 
 const UserProfile = () => {
   const [isNameEditorOpen, setIsNameEditorOpen] = useState(false)
@@ -52,7 +52,7 @@ const UserProfile = () => {
   }, [imageFile, patchImage, user, setUser])
 
   const handleNicknameChange = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       setError('')
       const value = e.target.value.replace(/\s/, '').slice(0, 7)
       if (!REGEX_NICKNAME.test(value)) {
@@ -64,10 +64,13 @@ const UserProfile = () => {
     []
   )
 
-  const handleNicknameSubmit = useCallback(() => {
-    const isNickNameExist = false
-    if (isNickNameExist) {
-      setError(ERROR_EXIST_NICKNAME)
+  const handleNicknameSubmit = useCallback(async () => {
+    const { data } = await axios.get(
+      `/accounts/check?property=${INPUT_NICKNAME}&value=${nickName}`
+    )
+    const { errorMessage } = data
+    if (errorMessage) {
+      setError(errorMessage)
       return
     }
 
@@ -95,9 +98,9 @@ const UserProfile = () => {
           <NickName ref={nameEditRef}>
             <ChangeNickNameInput
               type="text"
-              placeholder={CHANGE_NICKNAME_PLACEHOLDER}
+              placeholder={PLACEHOLDER_NICKNAME}
               onChange={handleNicknameChange}
-              isValid={Boolean(error)}
+              isValid={error ? false : true}
             />
             <ChangeNickNameButton onClick={handleNicknameSubmit}>
               수정

--- a/src/components/myInfo/UserProfile.tsx
+++ b/src/components/myInfo/UserProfile.tsx
@@ -28,12 +28,17 @@ const UserProfile = () => {
   const [error, setError] = useState('')
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [user, setUser] = useRecoilState<User>(currentUser)
-  const [isReset, setIsReset] = useState(false)
+  const [isReset, setIsReset] = useState(true)
 
   const { mutate: patchImage } = useChangeImageMutation()
   const { mutate: patchNickName } = useChangeNickNameMutation()
 
   const nameEditRef = useClickAway(() => setIsNameEditorOpen(false))
+
+  const handleProfileModalToggle = () => {
+    setIsProfileModalOpen((isProfileModalOpen) => !isProfileModalOpen)
+    setIsReset((isReset) => !isReset)
+  }
 
   const handleProfileChange = useCallback((file: File) => {
     setImageFile(file)
@@ -88,10 +93,7 @@ const UserProfile = () => {
         alt={user.nickName}
         width={140}
         height={140}
-        onClick={() => {
-          setIsProfileModalOpen(true)
-          setIsReset(false)
-        }}
+        onClick={handleProfileModalToggle}
       />
       {isNameEditorOpen ? (
         <>
@@ -116,10 +118,7 @@ const UserProfile = () => {
       )}
       <ProfileModal
         visible={isProfileModalOpen}
-        onClose={() => {
-          setIsProfileModalOpen(false)
-          setIsReset(true)
-        }}
+        onClose={handleProfileModalToggle}
         className="profile"
       >
         <ModalTitle>프로필을 바꾸시겠어요?</ModalTitle>

--- a/src/components/myInfo/UserProfile.tsx
+++ b/src/components/myInfo/UserProfile.tsx
@@ -28,6 +28,7 @@ const UserProfile = () => {
   const [error, setError] = useState('')
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [user, setUser] = useRecoilState<User>(currentUser)
+  const [isReset, setIsReset] = useState(false)
 
   const { mutate: patchImage } = useChangeImageMutation()
   const { mutate: patchNickName } = useChangeNickNameMutation()
@@ -84,7 +85,10 @@ const UserProfile = () => {
         alt={user.nickName}
         width={140}
         height={140}
-        onClick={() => setIsProfileModalOpen(true)}
+        onClick={() => {
+          setIsProfileModalOpen(true)
+          setIsReset(false)
+        }}
       />
       {isNameEditorOpen ? (
         <>
@@ -109,7 +113,10 @@ const UserProfile = () => {
       )}
       <ProfileModal
         visible={isProfileModalOpen}
-        onClose={() => setIsProfileModalOpen(false)}
+        onClose={() => {
+          setIsProfileModalOpen(false)
+          setIsReset(true)
+        }}
         className="profile"
       >
         <ModalTitle>프로필을 바꾸시겠어요?</ModalTitle>
@@ -118,6 +125,7 @@ const UserProfile = () => {
           size={14}
           onChange={handleProfileChange}
           value={user.image}
+          isReset={isReset}
         />
         <ModalButton onClick={handleProfileSubmit}>확인</ModalButton>
       </ProfileModal>

--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -1,8 +1,8 @@
 import { atom } from 'recoil'
 import { User } from '@interfaces'
-
+import { v1 } from 'uuid'
 export const currentUser = atom<User>({
-  key: 'currentUser',
+  key: `currentUser/${v1()}`,
   default: {
     id: 1,
     image:


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #149 

## 📌 기능 설명
- ImageUploader isReset prop 추가
- recoil key에 uuid로 난수 부여
- 내정보 닉네임 이미존재하는 닉네임인지 여부 검사
- 내정보 프로필 수정 모달 isReset으로 이미지 초기화



## 👩‍💻 요구 사항과 구현 내용

#### Signup 페이지는 잘못 들어갔네요 ㅜㅜ 빼고 봐주세요

### 1. ImageUploader isReset prop 추가
![image](https://user-images.githubusercontent.com/79133602/183445162-f6470278-6e5b-4121-93b2-0b5cfd1d89d2.png)

isReset(boolean) 여부로 ImageBox값이 prop으로 받은 value를 보일지 아니면 새로 받은 값을 보일지 결정

![image](https://user-images.githubusercontent.com/79133602/183445505-65c7dace-8c77-491f-9e30-73fb223016bb.png)



#### 사용방법

- isReset : true면 value로 받은 기본 이미지가 출력
![image](https://user-images.githubusercontent.com/79133602/183446041-8d8ffee5-b58f-4e7c-8c3b-32dff55ee5bf.png)

- isReset: false면 value가 아닌 onChange로 받은 DataURL이 출력
![image](https://user-images.githubusercontent.com/79133602/183445434-9c117925-ed80-486f-a124-2579691547e5.png)

### 2.  recoil key에 uuid로 난수 부여

[next js에서 recoil을 쓰면 duplicate key 경고를 만나는 데 uuid 난수를 키에 부여해서 해당 경고 해결](https://vaulted-count-177.notion.site/Duplicate-atom-key-currentUser-This-is-a-FATAL-ERROR-dab311dbe79f45c39425a5b63df101e6)

### 3. 내정보 닉네임 이미존재하는 닉네임인지 여부 검사
![image](https://user-images.githubusercontent.com/79133602/183446750-fad530df-5cb5-4645-b317-2cac65bc07fb.png)

useQuery의 refetch를 쓸까 했지만 그러면 api를 2번 호출해야 되고 현재 isError, onSuccess, isLoading 같은 useQuery의 값을 사용할 게 아니라서 직접 axiosInstance 호출

### 4, 내정보 프로필 수정 모달 isReset으로 이미지 초기화
1번 사용

## 구현 결과
![image](https://user-images.githubusercontent.com/79133602/183447399-4d0344a7-3993-4571-a339-6bad4b03d21a.png)
