### PR TITLE
feat: api 없이 로그아웃 removeLocalToken으로 구현

### DIFF
--- a/pages/myInfo/index.tsx
+++ b/pages/myInfo/index.tsx
@@ -10,7 +10,7 @@ const MyInfoPage = () => {
   const router = useRouter()
   const handleLogout = () => {
     removeLocalToken()
-    router.push(LOGIN_URL)
+    router.replace(LOGIN_URL)
   }
 
   return (

--- a/pages/myInfo/index.tsx
+++ b/pages/myInfo/index.tsx
@@ -4,9 +4,14 @@ import UserProfile from '@components/myInfo/UserProfile'
 import Button from '@components/Button'
 import { LOGIN_URL, PASSWORD_CHANGE_URL } from '@constants/pageUrl'
 import { useRouter } from 'next/router'
+import { removeLocalToken } from '@utils/localToken'
 
 const MyInfoPage = () => {
   const router = useRouter()
+  const handleLogout = () => {
+    removeLocalToken()
+    router.push(LOGIN_URL)
+  }
 
   return (
     <UserContainer>
@@ -15,9 +20,7 @@ const MyInfoPage = () => {
       <ChangePasswordButton onClick={() => router.push(PASSWORD_CHANGE_URL)}>
         비밀번호 변경
       </ChangePasswordButton>
-      <LogoutButton onClick={() => router.push(LOGIN_URL)}>
-        로그아웃
-      </LogoutButton>
+      <LogoutButton onClick={handleLogout}>로그아웃</LogoutButton>
     </UserContainer>
   )
 }

--- a/src/utils/localToken.ts
+++ b/src/utils/localToken.ts
@@ -20,5 +20,8 @@ export const setLocalToken = ({ accessToken, expirationTime }: Data) => {
 }
 
 export const removeLocalToken = () => {
-  typeof window !== undefined && window.localStorage.removeItem(LOCAL_TOKEN_KEY)
+  if (typeof window !== undefined) {
+    window.localStorage.removeItem(LOCAL_TOKEN_KEY)
+    window.localStorage.removeItem(LOCAL_TOKEN_EXPIRE_DATE)
+  }
 }


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #149 

## 📌 기능 설명

api 없이 로그아웃 removeLocalToken으로 구현

## 👩‍💻 요구 사항과 구현 내용

로그아웃 버튼 클릭 시 removeLocalToken 함수 사용, 그리고 로그인 페이지로 라우팅

## 구현 결과

![image](https://user-images.githubusercontent.com/79133602/183450986-0281c5cd-1919-4cf7-9ac6-012c741db5b1.png)
