### PR TITLE
refactor: 레이아웃 보완

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,11 +13,11 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <Layout>
-          <RecoilRoot>
+        <RecoilRoot>
+          <Layout>
             <Component {...pageProps} />
-          </RecoilRoot>
-        </Layout>
+          </Layout>
+        </RecoilRoot>
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -70,7 +70,7 @@ const UserMenu = () => {
 }
 
 const StickyWrapper = styled.div`
-  width: 100%auto;
+  width: 100% auto;
   position: sticky;
   top: 7.5rem;
   padding: 0.5rem 0;

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,8 +6,9 @@ import theme from '@constants/theme'
 import Link from 'next/link'
 import { useEffect, useState, useCallback } from 'react'
 import { MYINFO_URL, LOGIN_URL, USER_URL, HOME_URL } from '@constants/pageUrl'
+import { getLocalToken } from '@utils/localToken'
 
-const { mainPink, mainWhite, borderLight } = theme.color
+const { mainPink, mainWhite } = theme.color
 const { headerHeight, pagePadding } = theme.layout
 
 const MYINFO = '내정보'
@@ -17,9 +18,17 @@ export const Header = () => {
   const router = useRouter()
   const { pathname } = router
   const [title, setTitle] = useState('')
+  const [token, setToken] = useState('')
+
   const onClickPrev = () => {
     router.back()
   }
+
+  useEffect(() => {
+    if (pathname === LOGIN_URL || pathname === HOME_URL) {
+      setToken(getLocalToken() || '')
+    }
+  }, [token, pathname])
 
   const handlePathChange = useCallback((pathname: string) => {
     if (pathname === MYINFO_URL) {
@@ -47,18 +56,23 @@ export const Header = () => {
           </a>
         </Link>
       )}
-      <InnerRight>
-        <Link href={MYINFO_URL}>
-          <a>
-            <StyledUserIcon />
-          </a>
-        </Link>
-        <Link href={LOGIN_URL}>
-          <a>
-            <StyledLoginIcon />
-          </a>
-        </Link>
-      </InnerRight>
+      {pathname !== LOGIN_URL && (
+        <InnerRight>
+          {token ? (
+            <Link href={MYINFO_URL}>
+              <a>
+                <StyledUserIcon />
+              </a>
+            </Link>
+          ) : (
+            <Link href={LOGIN_URL}>
+              <a>
+                <StyledLoginIcon />
+              </a>
+            </Link>
+          )}
+        </InnerRight>
+      )}
     </HeaderContainer>
   )
 }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -2,14 +2,10 @@ import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { VscChevronLeft } from 'react-icons/vsc'
 import { FiLogIn, FiUser } from 'react-icons/fi'
-import theme from '@constants/theme'
 import Link from 'next/link'
 import { useEffect, useState, useCallback } from 'react'
 import { MYINFO_URL, LOGIN_URL, USER_URL, HOME_URL } from '@constants/pageUrl'
 import { getLocalToken } from '@utils/localToken'
-
-const { mainPink, mainWhite } = theme.color
-const { headerHeight, pagePadding } = theme.layout
 
 const MYINFO = '내정보'
 const USER = '메뉴판'
@@ -78,19 +74,19 @@ export const Header = () => {
 }
 
 const HeaderContainer = styled.div`
-  height: ${headerHeight};
+  height: ${(props) => props.theme.layout.headerHeight};
   position: fixed;
   max-width: 50rem;
   margin: 0 auto;
   left: 0;
   right: 0;
   z-index: 100;
-  background-color: ${mainPink};
+  background-color: ${(props) => props.theme.color.mainPink};
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 ${pagePadding};
-  color: ${mainWhite};
+  padding: 0 ${(props) => props.theme.layout.pagePadding};
+  color: ${(props) => props.theme.color.mainWhite};
 `
 
 const StyledBackIcon = styled(VscChevronLeft)`
@@ -123,7 +119,7 @@ const Logo = styled.div`
 const InnerRight = styled.div`
   position: absolute;
   top: 50%;
-  right: ${pagePadding};
+  right: ${(props) => props.theme.layout.pagePadding};
   transform: translateY(-50%);
   display: flex;
 

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -4,12 +4,17 @@ import { BiHomeAlt, BiSearch } from 'react-icons/bi'
 import { VscBook } from 'react-icons/vsc'
 import theme from '@constants/theme'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import { getLocalToken } from '@utils/localToken'
+import { useRecoilState } from 'recoil'
+import { currentUser } from '@recoil/currentUser'
 import {
   CREATE_MENU_URL,
   USER_URL,
   SEARCH_URL,
-  HOME_URL
+  HOME_URL,
+  LOGIN_URL
 } from '@constants/pageUrl'
 
 const { mainPink, mainWhite, borderLight } = theme.color
@@ -22,6 +27,14 @@ type IconType = {
 export const Navigation = () => {
   const router = useRouter()
   const { pathname } = router
+  const [token, setToken] = useState('')
+  const [user] = useRecoilState(currentUser)
+
+  useEffect(() => {
+    if (pathname === LOGIN_URL || pathname === HOME_URL) {
+      setToken(getLocalToken() || '')
+    }
+  }, [token, pathname])
 
   return (
     <NavContainer>
@@ -33,7 +46,7 @@ export const Navigation = () => {
             </NavItem>
           </StyledAnchor>
         </Link>
-        <Link href={CREATE_MENU_URL}>
+        <Link href={token ? CREATE_MENU_URL : LOGIN_URL}>
           <StyledAnchor>
             <NavItem>
               <StyledPlus selected={pathname === CREATE_MENU_URL} />
@@ -47,10 +60,9 @@ export const Navigation = () => {
             </NavItem>
           </StyledAnchor>
         </Link>
-        <Link href={USER_URL}>
+        <Link href={token ? `${USER_URL}/${user.id}` : LOGIN_URL}>
           <StyledAnchor>
             <NavItem>
-              {/* //todo신영 USER_URL 뒤에 /userId query param 넘겨주기 */}
               <StyledMenu selected={pathname === USER_URL} />
             </NavItem>
           </StyledAnchor>
@@ -72,9 +84,8 @@ const StyledAnchor = styled.a`
 
 const NavContainer = styled.div`
   height: ${navHeight};
-  position: fixed;
+  position: sticky;
   max-width: 50rem;
-  margin: 0 auto;
   left: 0;
   right: 0;
   bottom: 0;

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -46,7 +46,7 @@ export const Navigation = () => {
             </NavItem>
           </StyledAnchor>
         </Link>
-        <Link href={`${USER_URL}`}>
+        <Link href={`${USER_URL}/${user.id}`}>
           <StyledAnchor>
             <NavItem>
               <StyledMenu selected={pathname === USER_URL} />

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -2,23 +2,16 @@ import styled from '@emotion/styled'
 import { AiOutlinePlusSquare } from 'react-icons/ai'
 import { BiHomeAlt, BiSearch } from 'react-icons/bi'
 import { VscBook } from 'react-icons/vsc'
-import theme from '@constants/theme'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { getLocalToken } from '@utils/localToken'
 import { useRecoilState } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 import {
   CREATE_MENU_URL,
   USER_URL,
   SEARCH_URL,
-  HOME_URL,
-  LOGIN_URL
+  HOME_URL
 } from '@constants/pageUrl'
-
-const { mainPink, mainWhite, borderLight } = theme.color
-const { navHeight, pagePadding } = theme.layout
 
 type IconType = {
   selected?: boolean
@@ -27,14 +20,7 @@ type IconType = {
 export const Navigation = () => {
   const router = useRouter()
   const { pathname } = router
-  const [token, setToken] = useState('')
   const [user] = useRecoilState(currentUser)
-
-  useEffect(() => {
-    if (pathname === LOGIN_URL || pathname === HOME_URL) {
-      setToken(getLocalToken() || '')
-    }
-  }, [token, pathname])
 
   return (
     <NavContainer>
@@ -46,7 +32,7 @@ export const Navigation = () => {
             </NavItem>
           </StyledAnchor>
         </Link>
-        <Link href={token ? CREATE_MENU_URL : LOGIN_URL}>
+        <Link href={CREATE_MENU_URL}>
           <StyledAnchor>
             <NavItem>
               <StyledPlus selected={pathname === CREATE_MENU_URL} />
@@ -60,7 +46,7 @@ export const Navigation = () => {
             </NavItem>
           </StyledAnchor>
         </Link>
-        <Link href={token ? `${USER_URL}/${user.id}` : LOGIN_URL}>
+        <Link href={`${USER_URL}`}>
           <StyledAnchor>
             <NavItem>
               <StyledMenu selected={pathname === USER_URL} />
@@ -71,6 +57,7 @@ export const Navigation = () => {
     </NavContainer>
   )
 }
+
 const StyledAnchor = styled.a`
   width: 25%;
   text-align: center;
@@ -78,26 +65,26 @@ const StyledAnchor = styled.a`
   list-style: none;
 
   &:hover {
-    color: ${mainPink};
+    color: ${(props) => props.theme.color.mainPink};
   }
 `
 
 const NavContainer = styled.div`
-  height: ${navHeight};
-  position: sticky;
+  height: ${(props) => props.theme.layout.navHeight};
+  position: fixed;
   max-width: 50rem;
+  margin: 0 auto;
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 100;
   background-color: #ffffff;
-  border-bottom: 0.1rem solid ${borderLight};
-  padding: 0 ${pagePadding};
+  padding: 0 ${(props) => props.theme.layout.pagePadding};
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-top: 0.1rem solid ${borderLight};
-  background-color: ${mainWhite};
+  border-top: 0.1rem solid ${(props) => props.theme.color.borderLight};
+  background-color: ${(props) => props.theme.color.mainWhite};
 `
 
 const NavList = styled.ul`
@@ -113,25 +100,25 @@ const NavItem = styled.li``
 const StyledHome = styled(BiHomeAlt)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ selected }) => selected && theme.color.mainPink};
+  color: ${(props) => props.selected && props.theme.color.mainPink};
 `
 
 const StyledPlus = styled(AiOutlinePlusSquare)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ selected }) => selected && theme.color.mainPink};
+  color: ${(props) => props.selected && props.theme.color.mainPink};
 `
 
 const StyledSearch = styled(BiSearch)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ selected }) => selected && theme.color.mainPink};
+  color: ${(props) => props.selected && props.theme.color.mainPink};
 `
 
 const StyledMenu = styled(VscBook)<IconType>`
   width: 3rem;
   height: 3rem;
-  color: ${({ selected }) => selected && theme.color.mainPink};
+  color: ${(props) => props.selected && props.theme.color.mainPink};
 `
 
 export default Navigation

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,18 +1,36 @@
 import styled from '@emotion/styled'
-import { ReactNode } from 'react'
+import { ReactNode, useState, useEffect } from 'react'
 import Header from './Header'
 import Navigation from './Navigation'
+import { useRouter } from 'next/router'
+import { PASSWORD_CHANGE_URL, LOGIN_URL, SIGNUP_URL } from '@constants/pageUrl'
 
 interface Props {
   children: ReactNode
 }
 
 const Layout = ({ children }: Props) => {
+  const [isShow, setIsShow] = useState(true)
+  const router = useRouter()
+  const { pathname } = router
+  const isPathChangeNavigation =
+    pathname === LOGIN_URL ||
+    pathname === PASSWORD_CHANGE_URL ||
+    pathname === SIGNUP_URL
+
+  useEffect(() => {
+    if (isPathChangeNavigation) {
+      setIsShow(false)
+      return
+    }
+    setIsShow(true)
+  }, [pathname, isPathChangeNavigation])
+
   return (
     <Container id="default-template-container">
       <Header />
       <StyledMain>{children}</StyledMain>
-      <Navigation />
+      {isShow && <Navigation />}
     </Container>
   )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,10 @@ body {
   background-color: #f9f9f9;
 }
 
+::-webkit-scrollbar {
+  display: none;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #148 

## 📌 기능 설명

- 최종 디자인을 반영, 토큰 유무에 따라 다른 처리를 하도록 수정했습니다. 

## 👩‍💻 요구 사항과 구현 내용

### 1.  Navigation 회원가입, 로그인, 비밀번호 변경에선 제외
![image](https://user-images.githubusercontent.com/79133602/183656960-3f6ddbc0-5433-4442-a2e1-bf326eee4ce3.png)

### 2. 토큰 유무에 따라 Header 오른쪽 상단 메뉴 토글

![image](https://user-images.githubusercontent.com/79133602/183656457-70a78b6b-dae2-4d07-8fd2-9c1875698613.png)
현재 로그인 후, 로그아웃 후 메인, 로그인 페이지로 이동합니다. 그래서 이 때를 기점으로 토큰 유무를 판단하도록 코딩했습니다. 

### 3. 토큰 유무에 따라 Navigation Link href 다르게 처리

![image](https://user-images.githubusercontent.com/79133602/183656524-3365dd7a-0c9d-4a53-a408-4e3ad58610ab.png)

## 궁금증

### 1. 모바일 navigation 처리
현재 모바일 화면에서 input에 뭔 가를 입력하려 하면 키보드가 뜨고 키보드 위에 nav가 붙어서 답답합니다. 혹시 sticky로 바꾸면 스크롤 하지 않은 상태에선 키보드 아래에 있지 않을까 생각했는데 아닌 거 같아요... 혹시 해결 방안을 아실까요?

### 2. 로그아웃한 회원이 뒤로가기하면 인증회원만 볼 수 있는 페이지에 접근 가능 

이부분에 대해 고민을 많이 해봤는데, 제 결론은 `굳이 처리할 필요가 없다` 였습니다.
[해당 고민에 관한 글](https://vaulted-count-177.notion.site/a31268f8752d456bb60547cf9cadccac)
혹시 다른 의견이시라면 리뷰해주세요 👀

