### PR TITLE
fix: currentUser recoilEffects를 사용해서 로컬스토리지에 저장하고 전역상태관리

### DIFF
--- a/pages/myInfo/index.tsx
+++ b/pages/myInfo/index.tsx
@@ -1,10 +1,18 @@
 import styled from '@emotion/styled'
-import UserData from '@components/myInfo/UserData'
-import UserProfile from '@components/myInfo/UserProfile'
 import Button from '@components/Button'
 import { LOGIN_URL, PASSWORD_CHANGE_URL } from '@constants/pageUrl'
 import { useRouter } from 'next/router'
 import { removeLocalToken } from '@utils/localToken'
+import dynamic from 'next/dynamic'
+
+const UserProfileWithNoSSR = dynamic(
+  () => import('@components/myInfo/UserProfile'),
+  { ssr: false }
+)
+
+const UserDataWithNoSSR = dynamic(() => import('@components/myInfo/UserData'), {
+  ssr: false
+})
 
 const MyInfoPage = () => {
   const router = useRouter()
@@ -15,8 +23,8 @@ const MyInfoPage = () => {
 
   return (
     <UserContainer>
-      <UserProfile />
-      <UserData />
+      <UserProfileWithNoSSR />
+      <UserDataWithNoSSR />
       <ChangePasswordButton onClick={() => router.push(PASSWORD_CHANGE_URL)}>
         비밀번호 변경
       </ChangePasswordButton>

--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -3,15 +3,36 @@ import { User } from '@interfaces'
 import { v1 } from 'uuid'
 import { DEFAULT_USER_IMAGE } from '@constants/image'
 
+const initialUser = {
+  id: 1,
+  image: DEFAULT_USER_IMAGE,
+  email: '',
+  nickName: '',
+  snsAccount: '',
+  createdAt: '',
+  menuCount: 0
+}
+
+const localStorage = typeof window !== undefined ? window.localStorage : null
+
+const localStorageEffect =
+  (key: string) =>
+  ({ setSelf, onSet }: any) => {
+    const savedValue = localStorage && localStorage.getItem(key)
+
+    if (savedValue != null) {
+      setSelf(JSON.parse(savedValue) || initialUser)
+    }
+
+    onSet((newValue: string, _: any, isReset: boolean) => {
+      isReset
+        ? localStorage && localStorage.removeItem(key)
+        : localStorage && localStorage.setItem(key, JSON.stringify(newValue))
+    })
+  }
+
 export const currentUser = atom<User>({
   key: `currentUser/${v1()}`,
-  default: {
-    id: 1,
-    image: DEFAULT_USER_IMAGE,
-    email: '',
-    nickName: 'test',
-    snsAccount: '',
-    createdAt: '',
-    menuCount: 0
-  }
+  default: initialUser,
+  effects: [localStorageEffect(`currentUser`)]
 })


### PR DESCRIPTION
## 📌 기능 설명

브라우저 새로고침시 recoil State가 초기화되던 문제를 해결했습니다.

## 👩‍💻 요구 사항과 구현 내용

### currentUser에 변동 사항이 있으면 recoileffects가 작동하고

![image](https://user-images.githubusercontent.com/79133602/183856523-b8a85648-d0e7-488a-a9ea-6b8397d5d9e5.png)


### recoileffects에 지정해둔 `localStorageEffect('currentUser')`가 호출됩니다.
해당 함수는 현재 atom 키의 값을 로컬에 저장하는 작업을 합니다.
![image](https://user-images.githubusercontent.com/79133602/183856266-44b3e15a-bd19-408a-9d84-01212e30b8a1.png)

## 의문점 

원래 NEXT에서 SSR하는 동안 window가 undefined 상태라서 에러가 납니다. 그래서 아래같은 조건문으로 방어가 됐는데,
새로고침 시에는 방어가 되지 않았습니다.

![image](https://user-images.githubusercontent.com/79133602/183856570-03e5c37a-5212-4eb1-8b25-2e9ddde675e4.png)

그래서 어쩔 수 없이 currentUser를 사용하는 컴포넌트에 한해서 SSR을 꺼뒀습니다.

![image](https://user-images.githubusercontent.com/79133602/183856899-c7031e9d-a876-44e7-9589-d90a4f0b6c71.png)

저의 경우 해당 컴포넌트가 Recoil만 쓰고, get하는 정보가 없기에 SSR을 꺼도 불이익은 없다고 판단했습니다. 
