### PR TITLE
feat : 이미지 삭제 버튼 생성

### DIFF
--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -86,7 +86,7 @@ const CreateMenu = () => {
   return (
     <FlexContainer>
       <ImageUploaderWrapper>
-        <ImageUploader onChange={handleImageChange} />
+        <ImageUploader isDeletable={true} onChange={handleImageChange} />
       </ImageUploaderWrapper>
       <InputList
         franchiseId={franchiseId}

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -35,7 +35,7 @@ const CreateMenu = () => {
   const [expectedPrice, setExpectedPrice] = useState(0)
   const [isPriceButtonClicked, setIsPriceButtonClicked] = useState(false)
 
-  const handleImageChange = (file: File) => {
+  const handleImageChange = (file: File | null) => {
     setFile(file)
   }
 

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -98,7 +98,11 @@ const EditMenu = () => {
   return (
     <FlexContainer>
       <ImageUploaderWrapper>
-        <ImageUploader value={menuData?.image} onChange={handleImageChange} />
+        <ImageUploader
+          value={menuData?.image}
+          isDeletable={true}
+          onChange={handleImageChange}
+        />
       </ImageUploaderWrapper>
       <InputList
         franchiseId={franchiseId}

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -66,7 +66,7 @@ const EditMenu = () => {
   }
 
   // onChange handler
-  const handleImageChange = (file: File) => {
+  const handleImageChange = (file: File | null) => {
     setFile(file)
   }
 

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -33,7 +33,7 @@ import {
 import ImageUploader from '@components/ImageUploader'
 
 interface SignUpValues {
-  image?: File
+  image?: File | null
   email: string
   nickName: string
   password: string
@@ -178,7 +178,7 @@ const Signup = () => {
         )
   }, [])
 
-  const handleImageChange = (file: File) => {
+  const handleImageChange = (file: File | null) => {
     setValues({ ...values, image: file })
   }
 

--- a/src/components/FranchiseSelect.tsx
+++ b/src/components/FranchiseSelect.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 import { NAME_SELECT } from '@constants/menuConstant'
 
-const PLACEHOLDER_FRANCHISE_LIST = '해당하는 프렌차이즈를 선택해주세요'
+const PLACEHOLDER_FRANCHISE_LIST = '해당하는 프랜차이즈를 선택해주세요'
 interface Props {
   defaultValue?: number
   onChange: (e: React.FormEvent<HTMLSelectElement>) => void

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import React, { useEffect, useState } from 'react'
 import { ImageType } from '@customTypes/index'
 import { TbCameraPlus } from 'react-icons/tb'
+import { TiDelete } from 'react-icons/ti'
 
 const FILE_TYPE = 'image/gif, image/jpeg, image/png'
 const FILE_INPUT_NAME = 'image-input'
@@ -11,6 +12,7 @@ interface Props {
   shape?: 'square' | 'circle'
   value?: string | null
   isReset?: boolean
+  isDeletable?: boolean
   onChange: (file: File) => void
 }
 
@@ -19,6 +21,7 @@ const ImageUploader = ({
   shape = 'square',
   value = null,
   isReset = true,
+  isDeletable = false,
   onChange
 }: Props) => {
   const [image, setImage] = useState<ImageType>(value)
@@ -31,6 +34,9 @@ const ImageUploader = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
+    if (!file) {
+      return
+    }
     if (!file?.name.match(FILE_REGEX)) {
       setIsError(true)
       return
@@ -43,6 +49,13 @@ const ImageUploader = ({
     }
   }
 
+  const handleDeleteButtonClick = (
+    e: React.MouseEvent<SVGElement, MouseEvent>
+  ) => {
+    e.preventDefault()
+    setImage(null)
+  }
+
   return (
     <>
       <ImageBox
@@ -51,7 +64,12 @@ const ImageUploader = ({
         shape={shape}
         image={image}
       >
-        <StyledIcon selected={Boolean(image)} />
+        {isDeletable && image ? (
+          <DeleteIcon onClick={handleDeleteButtonClick} />
+        ) : (
+          ''
+        )}
+        <StyledPlus selected={Boolean(image)} />
       </ImageBox>
       {isError ? (
         <ErrorMessage>확장자는 jpg, png, jpeg 만 가능해요!</ErrorMessage>
@@ -76,6 +94,7 @@ const ImageBox = styled.label<{
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
   width: ${({ size }) => (size ? `${size}rem` : '100%')};
   height: ${({ size }) => `${size}rem`};
   padding-top: ${({ size }) => (size ? `0` : 'calc(50% - 5rem)')};
@@ -91,11 +110,20 @@ const ImageBox = styled.label<{
   }
 `
 
-const StyledIcon = styled(TbCameraPlus)<{ selected: boolean }>`
+const StyledPlus = styled(TbCameraPlus)<{ selected: boolean }>`
   width: 10rem;
   height: 10rem;
   color: white;
   visibility: ${({ selected }) => (selected ? 'hidden' : 'visible')};
+`
+
+const DeleteIcon = styled(TiDelete)`
+  position: absolute;
+  top: 0.8rem;
+  right: 0.8rem;
+  width: 5rem;
+  height: 5rem;
+  padding: 0.5rem;
 `
 
 const ErrorMessage = styled.div`

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -13,7 +13,7 @@ interface Props {
   value?: string | null
   isReset?: boolean
   isDeletable?: boolean
-  onChange: (file: File) => void
+  onChange: (file: File | null) => void
 }
 
 const ImageUploader = ({
@@ -34,6 +34,7 @@ const ImageUploader = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
+    console.log(file)
     if (!file) {
       return
     }
@@ -47,6 +48,7 @@ const ImageUploader = ({
       setImage(reader.result)
       onChange(file)
     }
+    e.target.value = ''
   }
 
   const handleDeleteButtonClick = (
@@ -54,6 +56,7 @@ const ImageUploader = ({
   ) => {
     e.preventDefault()
     setImage(null)
+    onChange(null)
   }
 
   return (

--- a/src/components/myInfo/UserProfile.tsx
+++ b/src/components/myInfo/UserProfile.tsx
@@ -45,7 +45,7 @@ const UserProfile = () => {
     setIsReset(true)
   }
 
-  const handleProfileChange = useCallback((file: File) => {
+  const handleProfileChange = useCallback((file: File | null) => {
     setImageFile(file)
   }, [])
 

--- a/src/constants/menuConstant.ts
+++ b/src/constants/menuConstant.ts
@@ -22,4 +22,4 @@ export const ERROR_MESSAGE_REQUIRED_OPTION_TEXT =
   '옵션 이름과 설명을 입력해주세요'
 export const ERROR_MESSAGE_REQUIRED_OPTION = '옵션은 최소 1개 이상이어야 해요'
 export const ERROR_MESSAGE_REQUIRED_FRANCHISE =
-  '프렌차이즈 이름은 필수로 선택해야 해요'
+  '프랜차이즈 이름은 필수로 선택해야 해요'

--- a/src/hooks/mutations/useSignupMutation.ts
+++ b/src/hooks/mutations/useSignupMutation.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useLoginMutation } from '@hooks/mutations/useLoginMutation'
 
 interface Params {
-  image?: File
+  image?: File | null
   email: string
   nickName: string
   password: string


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #165 
## 📌 기능 설명

- 이미지 삭제가 가능하도록 ImageUploader 컴포넌트에서 이미지 삭제 버튼을 구현했습니다. 

## 👩‍💻 요구 사항과 구현 내용
- 이미지 삭제 버튼 구현 
- 이미지 삭제 가능 여부에 따라 isDeletable Prop 받음

이미지 삭제 핸들러
```js
  const handleDeleteButtonClick = (
    e: React.MouseEvent<SVGElement, MouseEvent>
  ) => {
    e.preventDefault() // 버블링 막기 위해 사용
    setImage(null)
    onChange(null)
  }

```

<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과

<!-- 이미지를 첨부해주세요. -->
<img width="323" alt="image" src="https://user-images.githubusercontent.com/75849590/183995200-d8c5b87d-8952-4539-b2fb-7ef55f842230.png">

- 현재는 버튼의 사이즈를 고정해놓았는데, 이미지 업로더 컴포넌트가 작아짐에 따라 크기 변경 미디어 쿼리를
사용해야 합니다. 하지만 현재는 수정 / 생성 페이지에서만 사용해서 고정해놓았습니다. 
