### PR TITLE
feat: 메뉴 상세 페이지 댓글 삭제

### DIFF
--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -5,6 +5,7 @@ import { Comment, User } from '@interfaces'
 import { BiDotsHorizontalRounded, BiTrash } from 'react-icons/bi'
 import { getDate } from '@utils/getDate'
 import Avatar from '@components/Avatar'
+import { useDeleteCommentMutation } from '@hooks/mutations/useDeleteCommentMutation'
 
 interface Props {
   user: User
@@ -12,14 +13,30 @@ interface Props {
 }
 
 const CommentList = ({ user, commentList }: Props) => {
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [commentId, setCommentId] = useState(0)
+  const { mutate: deleteComment } = useDeleteCommentMutation()
 
-  const handleDeleteCommentClick = () => {
-    setIsDeleteModalOpen(true)
+  const handleCommentModalClick = (id: number) => {
+    setIsModalOpen(true)
+    setCommentId(id)
   }
 
-  const handleDeleteCommentClose = () => {
-    setIsDeleteModalOpen(false)
+  const handleCommentModalClose = () => {
+    setIsModalOpen(false)
+  }
+
+  const handleDeleteCommentClick = () => {
+    deleteComment(
+      {
+        commentId
+      },
+      {
+        onSuccess: () => {
+          setIsModalOpen(false)
+        }
+      }
+    )
   }
 
   return (
@@ -38,7 +55,10 @@ const CommentList = ({ user, commentList }: Props) => {
                   </NameAndDateWrapper>
                   {user.id === author.id && (
                     <>
-                      <Dots size={20} onClick={handleDeleteCommentClick} />
+                      <Dots
+                        size={20}
+                        onClick={() => handleCommentModalClick(id)}
+                      />
                     </>
                   )}
                 </CommentHeader>
@@ -49,11 +69,11 @@ const CommentList = ({ user, commentList }: Props) => {
         ))}
       </CommentListContainer>
       <Modal
-        visible={isDeleteModalOpen}
-        onClose={handleDeleteCommentClose}
+        visible={isModalOpen}
+        onClose={handleCommentModalClose}
         option="drawer"
       >
-        <ModalItem>
+        <ModalItem onClick={handleDeleteCommentClick}>
           <BiTrash size={25} />
           삭제
         </ModalItem>

--- a/src/hooks/mutations/useDeleteCommentMutation.ts
+++ b/src/hooks/mutations/useDeleteCommentMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from '@lib/axios'
+
+interface Params {
+  commentId: number
+}
+
+interface Data {
+  menuId: number
+}
+
+const deleteComment = async ({ commentId }: Params) => {
+  const { data } = await axios.delete<Data>(`/comments/${commentId}`)
+
+  return data
+}
+
+export const useDeleteCommentMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation(deleteComment, {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries([`comments`, data.menuId])
+    }
+  })
+}


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #183 
## 📌 기능 설명
메뉴 상세 페이지 댓글 삭제

## 👩‍💻 요구 사항과 구현 내용
댓글 작성자가 댓글을 단 뒤 오른쪽에 있는 Dots를 눌러 모달을 열고, 모달의 삭제 버튼을 누르면 댓글이 삭제되는데 API가 문제가 있는 듯 해서 화면에 바로 반영은 되지 않고 있습니다.

## 구현 결과
<img width="365" alt="스크린샷 2022-08-11 23 33 00" src="https://user-images.githubusercontent.com/81501723/184158165-2e3c0873-6dcc-449c-ade5-0484a47d97da.png">

