### PR TITLE
hotfix: useSearchMenu 조건 초기화

### DIFF
--- a/src/hooks/queries/useSearchMenuList.ts
+++ b/src/hooks/queries/useSearchMenuList.ts
@@ -46,7 +46,7 @@ export const useSearchMenuList = (params: searchParams) => {
       getNextPageParam: (lastPage) => {
         return !lastPage.isLast ? lastPage.nextPage : undefined
       },
-      enabled: !!franchiseId
+      enabled: franchiseId !== undefined
     }
   )
 


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명

이전 PR #191 에서 useSearchMenu 훅 enabled 조건을

`enabled: franchiseId !== undefined` 에서 `enabled: !!franchiseId`로 변경했습니다.
해당 부분이 이전 API로 인한 레거시인줄 착각하고 바꿨는데, 수정후 동작시켜보니 franchiseId가 0일때 전체검색이 동작하기 때문에 기존 조건으로 다시 복구가 필요합니다!
