### PR TITLE
fix: 로그인 오타 수정 및 토큰 쿠키 관련 조건 변경

### DIFF
--- a/src/hooks/mutations/useLoginMutation.ts
+++ b/src/hooks/mutations/useLoginMutation.ts
@@ -23,10 +23,7 @@ interface Data {
 }
 
 const postLogin = async ({ email, password }: Params) => {
-  const { data } = await axios.post<Data>(
-    '/',
-    JSON.stringify({ email, password })
-  )
+  const { data } = await axios.post<Data>('/login', { email, password })
 
   return data
 }

--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -3,6 +3,7 @@ import { User } from '@interfaces'
 import { v1 } from 'uuid'
 import { DEFAULT_USER_IMAGE } from '@constants/image'
 import { setCookie, getCookie } from '@utils/cookie'
+import { TOKEN_EXPIRE_DATE, CURRENT_USER } from '@constants/token'
 
 export const initialUser = {
   id: 0,
@@ -24,12 +25,18 @@ const makeCookieEffect =
     }
 
     onSet((newValue: User, _: any, isReset: boolean) => {
-      isReset ? setCookie(key, '') : setCookie(key, JSON.stringify(newValue))
+      const expirationDate = getCookie(TOKEN_EXPIRE_DATE)
+      isReset
+        ? setCookie(key, '')
+        : setCookie(key, JSON.stringify(newValue), {
+            path: '/',
+            expires: new Date(expirationDate)
+          })
     })
   }
 
 export const currentUser = atom<User>({
   key: `currentUser/${v1()}`,
   default: initialUser,
-  effects: [makeCookieEffect('currentUser')]
+  effects: [makeCookieEffect(CURRENT_USER)]
 })

--- a/src/utils/checkToken.ts
+++ b/src/utils/checkToken.ts
@@ -1,18 +1,30 @@
 import { AxiosRequestConfig } from 'axios'
-import { getTokenData, setToken } from '@utils/cookie'
+import { getTokenData, setToken, removeTokenData } from '@utils/cookie'
 import moment from 'moment'
 import axios from 'axios'
 
 export const checkToken = async (config: AxiosRequestConfig) => {
-  const { currentUser, tastyToken, tastyToken_expire, tastyRefreshToken } =
-    getTokenData()
+  const {
+    currentUser,
+    tastyToken,
+    tastyToken_expire,
+    tastyRefreshToken,
+    tastyRefreshToken_expire
+  } = getTokenData()
 
   if (!config?.headers) {
     throw new Error(`Axios config headers must be provided`)
   }
 
   if (
-    moment(tastyToken_expire).diff(moment(), 'minutes') < 10 &&
+    moment(tastyRefreshToken_expire).diff(moment(), 'minutes') < 1 &&
+    tastyRefreshToken
+  ) {
+    removeTokenData()
+  }
+
+  if (
+    moment(tastyToken_expire).diff(moment(), 'minutes') < 1 &&
     tastyRefreshToken
   ) {
     const { data } = await axios.post(


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #189

## 📌 기능 설명

- 로그인 오타 수정
- checkToken 조건 변경 
- makeCookieEffects 옵션 변경 

## 👩‍💻 요구 사항과 구현 내용

### 1. 로그인 오타 수정
![image](https://user-images.githubusercontent.com/79133602/184307507-e4092cbc-7ff1-4b9c-8a50-8f70dd3e6c0b.png)

### 2.  checkToken 조건 변경 

- accessToken 만료 시간이 1분 남았을 때 토큰을 재발급하도록 변경 
- refreshToken 만료시간이 1분 남았을 땐 자동로그아웃 

![image](https://user-images.githubusercontent.com/79133602/184307556-44107b25-4f91-49a3-b21f-81ba9723de49.png)

### 왜 1분으로 기준을 잡았는지?
서버 처리시간이 차이가 나기 때문, 만료시간이 1시 10분이 토큰이 있을 때, 1:09분에 요청을 보내면 재발급 없이 기존 토큰을 사용한다. 그런데 해당 토큰이 서버에선 1:10분에 도착, 에러가 날 수 있어서 여유 시간 1분을 줬다. 

- 아래 링크에선 30초를 줬는데 전 좀 더 줬습니다. 

[참고 링크](https://han-um.tistory.com/17)

### 3.  makeCookieEffects 옵션 변경 

기존 코드에선 currentUser의 값이 변경될 때 옵션이 기본값이라 세션 쿠키로 바뀌는 버그가 있었음. 자동 로그인 유지를 위해 옵션에 accessToken의 expirationDate만큼 expires를 줌

![image](https://user-images.githubusercontent.com/79133602/184307904-2358a34a-97de-4139-93a9-e19ee1a9390d.png)

## 구현 결과
![image](https://user-images.githubusercontent.com/79133602/184308266-571352f5-2c48-41b2-b772-03e02c7e2281.png)

