### PR TITLE
feat: 상세 페이지 SSR 적용

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,20 +5,26 @@ import { ThemeProvider } from '@emotion/react'
 import theme from '@constants/theme'
 import { RecoilRoot } from 'recoil'
 import React from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  Hydrate,
+  QueryClient,
+  QueryClientProvider
+} from '@tanstack/react-query'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <RecoilRoot>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </RecoilRoot>
-      </ThemeProvider>
+      <Hydrate state={pageProps.dehydratedState}>
+        <ThemeProvider theme={theme}>
+          <RecoilRoot>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </RecoilRoot>
+        </ThemeProvider>
+      </Hydrate>
     </QueryClientProvider>
   )
 }

--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -6,6 +6,10 @@ import { useMenu } from '@hooks/queries/useMenu'
 import { useRecoilState } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 import { useCommentList } from '@hooks/queries/useCommentList'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { GetServerSidePropsContext } from 'next'
+import axios from 'axios'
+import { Menu } from '@interfaces'
 
 const Detail = () => {
   const router = useRouter()
@@ -28,6 +32,34 @@ const Detail = () => {
       )}
     </>
   )
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const menuId = parseInt(context.query.id as string, 10)
+  const queryClient = new QueryClient()
+
+  const getMenuById = async (menuId: number) => {
+    if (!context.req.cookies['tastyToken']) {
+      return
+    }
+
+    const { data } = await axios.get<Menu>(
+      `${process.env.NEXT_PUBLIC_API_URL}/menu/${menuId}`,
+      {
+        headers: { Authorization: context.req.cookies['tastyToken'] }
+      }
+    )
+
+    return data
+  }
+
+  await queryClient.prefetchQuery(['menu', menuId], () => getMenuById(menuId), {
+    staleTime: 10000
+  })
+
+  return { props: { dehydratedState: dehydrate(queryClient) } }
 }
 
 export default Detail


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #162
## 📌 기능 설명
메뉴 상세 페이지에 SSR을 적용
## 👩‍💻 요구 사항과 구현 내용
- 메뉴 정보를 불러오는 데에 서버 사이드 렌더링을 적용했습니다.
- 댓글은 기존의 CSR 방식으로 불러오는데 후에 필요하다면 적용은 어렵지 않을 것으로 생각됩니다.
## 구현 결과
움짤로 올리고 싶었으나 아래 링크를 누르면 녹화된 영상이 다운로드가 됩니다. 궁금하시면 눌러서 확인해보시면 좋을 것 같습니다.
https://user-images.githubusercontent.com/81501723/184471893-e4ae2d58-bf26-46b1-acd5-8b1c42820e0c.mov
https://user-images.githubusercontent.com/81501723/184471899-340f946b-794b-4318-98c1-ad17b6b6d4a3.mov


