### PR TITLE
fix: InfintieQuery isLast 조건 수정

### DIFF
--- a/src/hooks/queries/useSearchMenuList.ts
+++ b/src/hooks/queries/useSearchMenuList.ts
@@ -23,7 +23,7 @@ const getMenuList = async (params: searchParams) => {
       offset: params.offset + params.limit,
       limit: params.limit
     },
-    isLast: !data
+    isLast: !data.menu
   }
 }
 

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -24,7 +24,7 @@ const getMyMenuList = async (params: searchParams) => {
       offset: params.offset + params.limit,
       limit: params.limit
     },
-    isLast: !data
+    isLast: !data.menu
   }
 }
 


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명

InfiniteQuery의 isLast 조건으로 마지막 페이지인지 아닌지를 판단하는 조건 수정

## 👩‍💻 요구 사항과 구현 내용

현재 마지막페이지 조건이 잘못 입력되어서 마지막 페이지에서 무한으로 api를 쏘는 버그가 있어서 급히 수정했습니다!
확인하신 순서대로 approve해주시면 감사하겠습니다!

