### PR TITLE
fix: 미들웨어 redirect 문제 수정

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,32 +1,27 @@
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 import { TOKEN_KEY } from '@constants/token'
-import {
-  CREATE_MENU_URL,
-  EDIT_MENU_URL,
-  MYINFO_URL,
-  PASSWORD_CHANGE_URL,
-  USER_URL,
-  LOGIN_URL,
-  SIGNUP_URL
-} from '@constants/pageUrl'
-const TOKEN_REQUIRED_URL_LIST = [
-  CREATE_MENU_URL,
-  MYINFO_URL,
-  PASSWORD_CHANGE_URL,
-  EDIT_MENU_URL,
-  USER_URL,
-  SIGNUP_URL
-]
+import { SIGNUP_URL, LOGIN_URL, HOME_URL } from '@constants/pageUrl'
 
 export function middleware(req: NextRequest, ev: NextFetchEvent) {
   const { pathname } = req.nextUrl
-  if (
-    TOKEN_REQUIRED_URL_LIST.includes(pathname) &&
-    !req.cookies.get(TOKEN_KEY)
-  ) {
-    const url = req.nextUrl.clone()
-    url.pathname = LOGIN_URL
-    return NextResponse.redirect(`${url}`)
+  const url = req.nextUrl.clone()
+  if (pathname === SIGNUP_URL && req.cookies.get(TOKEN_KEY)) {
+    url.pathname = HOME_URL
+    return NextResponse.redirect(url)
   }
+  if (pathname !== SIGNUP_URL && !req.cookies.get(TOKEN_KEY)) {
+    url.pathname = LOGIN_URL
+    return NextResponse.redirect(url)
+  }
+}
+
+export const config = {
+  matcher: [
+    '/create-menu',
+    '/edit-menu/:path*',
+    '/myInfo/:path*',
+    '/user/:path*',
+    '/signup'
+  ]
 }

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -34,7 +34,6 @@ const ImageUploader = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const reader = new FileReader()
     const file = e.target.files ? e.target.files[0] : null
-    console.log(file)
     if (!file) {
       return
     }


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명
- 기존에 미들웨어에서 redirect 조건이 문자열 일치여서 완전 일치하지 않는 url(예를 들어 /user/:id) 일때는 걸러주지 못하는 문제를 발견했습니다.

- 또한 signup의 로직이 로그인 시 접근 불가인데 반대로 설정했습니다. 

따라서 미들웨어의 config 기능등을 사용해서 기존의 redirect 문제들과, signup 로직을 수정했습니다. 
<!-- 기능을 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용

변수 사용이 안되어서 config에 url들을 문자열로 적었습니다.
config 에 있는 것만 middleware를 거칩니다. 
```js
export const config = {
  matcher: [
    '/create-menu',
    '/edit-menu/:path*',
    '/myInfo/:path*',
    '/user/:path*',
    '/signup'
  ]
}

```
<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과

<!-- 이미지를 첨부해주세요. -->
