### PR TITLE
refactor: 레이아웃 최종 디자인 반영 및 토큰 SSR로 받도록 수정

### DIFF
--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -23,6 +23,7 @@ const Category = () => {
 
 const FixedWrapper = styled.div`
   position: fixed;
+  top: 6.4rem;
   left: 0;
   width: 100%;
 `

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -31,8 +31,10 @@ const FixedWrapper = styled.div`
 const InnerWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   min-width: 33.5rem;
   max-width: 46rem;
+  height: 6.4rem;
   width: 100%;
   background-color: white;
   margin: 0 auto;

--- a/pages/user/[id].tsx
+++ b/pages/user/[id].tsx
@@ -79,7 +79,7 @@ const UserMenu = () => {
 const StickyWrapper = styled.div`
   width: 100% auto;
   position: sticky;
-  top: 7.5rem;
+  top: 6.4rem;
   padding: 0.5rem 0;
   background-color: white;
 `

--- a/src/components/FranchiseInfoList.tsx
+++ b/src/components/FranchiseInfoList.tsx
@@ -38,7 +38,7 @@ const BoxContainer = styled.ul`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-top: 8.5rem;
+  padding-top: 6.4rem;
 `
 
 const BoxWrapper = styled.li`

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -3,16 +3,11 @@ import { useRouter } from 'next/router'
 import { IoChevronBackSharp } from 'react-icons/io5'
 import { FiLogIn, FiUser } from 'react-icons/fi'
 import Link from 'next/link'
-import { useEffect, useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { MYINFO_URL, LOGIN_URL, USER_URL, HOME_URL } from '@constants/pageUrl'
-import { TOKEN_KEY } from '@constants/token'
+import { getToken } from '@utils/cookie'
 import { SMALL_LOGO } from '@constants/image'
 import Image from 'next/image'
-import { GetServerSidePropsContext } from 'next'
-
-interface Props {
-  token?: string
-}
 
 type IconType = {
   selected?: boolean
@@ -21,10 +16,16 @@ type IconType = {
 const TITLE_MYINFO = '내정보'
 const TITLE_USER = '메뉴판'
 
-export const Header = (token: Props) => {
+export const Header = () => {
   const router = useRouter()
   const { pathname } = router
   const [title, setTitle] = useState('')
+
+  const [token, setToken] = useState('')
+
+  useEffect(() => {
+    setToken(getToken() || '')
+  }, [token, pathname])
 
   const onClickPrev = () => {
     router.back()
@@ -82,16 +83,6 @@ export const Header = (token: Props) => {
       )}
     </HeaderContainer>
   )
-}
-
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  if (!context.req.cookies[TOKEN_KEY]) {
-    return
-  }
-
-  return context.req.cookies[TOKEN_KEY]
 }
 
 const HeaderContainer = styled.div`

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -5,39 +5,37 @@ import { FiLogIn, FiUser } from 'react-icons/fi'
 import Link from 'next/link'
 import { useEffect, useState, useCallback } from 'react'
 import { MYINFO_URL, LOGIN_URL, USER_URL, HOME_URL } from '@constants/pageUrl'
-import { getToken } from '@utils/cookie'
+import { TOKEN_KEY } from '@constants/token'
 import { SMALL_LOGO } from '@constants/image'
 import Image from 'next/image'
+import { GetServerSidePropsContext } from 'next'
+
+interface Props {
+  token?: string
+}
 
 type IconType = {
   selected?: boolean
 }
 
-const MYINFO = '내정보'
-const USER = '메뉴판'
+const TITLE_MYINFO = '내정보'
+const TITLE_USER = '메뉴판'
 
-export const Header = () => {
+export const Header = (token: Props) => {
   const router = useRouter()
   const { pathname } = router
   const [title, setTitle] = useState('')
-  const [token, setToken] = useState('')
 
   const onClickPrev = () => {
     router.back()
   }
 
-  useEffect(() => {
-    if (pathname === LOGIN_URL || pathname === HOME_URL) {
-      setToken(getToken() || '')
-    }
-  }, [token, pathname])
-
   const handlePathChange = useCallback((pathname: string) => {
     if (pathname === MYINFO_URL) {
-      setTitle(MYINFO)
+      setTitle(TITLE_MYINFO)
     }
     if (pathname.includes(USER_URL)) {
-      setTitle(USER)
+      setTitle(TITLE_USER)
     }
   }, [])
 
@@ -84,6 +82,16 @@ export const Header = () => {
       )}
     </HeaderContainer>
   )
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  if (!context.req.cookies[TOKEN_KEY]) {
+    return
+  }
+
+  return context.req.cookies[TOKEN_KEY]
 }
 
 const HeaderContainer = styled.div`

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -16,8 +16,8 @@ const theme = {
     franchiseLight: '#9EA4AA'
   },
   layout: {
-    headerHeight: '7.2rem',
-    navHeight: '7.2rem',
+    headerHeight: '6.4rem',
+    navHeight: '6.4rem',
     pagePadding: '2rem',
     layoutWidth: '50rem'
   }


### PR DESCRIPTION
## 📌 기능 설명

- 헤더, 네비 height 줄이기
- 헤더가 줄어든 만큼 카테고리, 메뉴판 fixed 요소들 top 수정 
- 헤더의 token 값 SSR로 처리하도록 수정

## 👩‍💻 요구 사항과 구현 내용

- 헤더, 네비 height 줄이기 : 6.4rem
- 카테고리, 메뉴판 fixed 요소들:  top:6.4rem
- 헤더의 token 값 SSR로 처리하도록 수정
새로고침 시 쿠키가 있어도 없다고 인식하는 문제가 있었는데 헤더를 렌더링할 때 getServerSideProp에서 token을 넘겨받는 식으로 해결했습니다. 

[ 자세한 내용 ](https://vaulted-count-177.notion.site/getToken-cbc769091ab1442e8599c05b60031ed8)

![image](https://user-images.githubusercontent.com/79133602/184505226-241ae5d4-b02b-4804-9ccd-edc4e5ebe01a.png)

