### PR TITLE
feat: 좋아요 여부 판단, 로그인 여부 판별 state 수정

### DIFF
--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const CommentInput = ({ menuId, userId }: Props) => {
   const [comment, setComment] = useState('')
-  const [isLoggedIn, setIsLoggedIn] = useState(true)
+  const [isLoggedIn] = useState(!userId)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const { mutate: postComment } = usePostCommentMutation()
 

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -16,11 +16,11 @@ interface Props {
 }
 
 const MenuDetail = ({ menu, userId }: Props) => {
+  const [isLikeClicked, setIsLikeClicked] = useState(menu.isLiked)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { mutate: deleteMenu } = useDeleteMenuMutation()
-  const router = useRouter()
-  const [isLikeClicked, setIsLikeClicked] = useState(false)
   const { mutate: postLike } = usePostLikeMutation({ menuId: menu.id })
+  const router = useRouter()
 
   const handleHeartClick = () => {
     postLike(

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -20,6 +20,7 @@ export interface Menu {
   expectedPrice: number
   tasteList: Taste[]
   likes: number
+  isLiked: boolean
   comments: number
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명
메뉴 상세 페이지

## 👩‍💻 요구 사항과 구현 내용
- Menu interface에 `isLiked` 필드 추가
  - 하트의 색 초기값으로 사용
- 로그인 여부 판별 state 수정(currentUser의 id를 통해 비교)
