### PR TITLE
fix / 수정 / 생성 시 버튼 한번만 누르게 처리

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,17 @@
 import { NextResponse } from 'next/server'
-import type { NextFetchEvent, NextRequest } from 'next/server'
+import type { NextRequest } from 'next/server'
 import { TOKEN_KEY } from '@constants/token'
 import { SIGNUP_URL, LOGIN_URL, HOME_URL } from '@constants/pageUrl'
 
-export function middleware(req: NextRequest, ev: NextFetchEvent) {
+export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl
   const url = req.nextUrl.clone()
-  if (pathname === SIGNUP_URL && req.cookies.get(TOKEN_KEY)) {
-    url.pathname = HOME_URL
-    return NextResponse.redirect(url)
-  }
   if (pathname !== SIGNUP_URL && !req.cookies.get(TOKEN_KEY)) {
     url.pathname = LOGIN_URL
+    return NextResponse.redirect(url)
+  }
+  if (pathname === SIGNUP_URL && req.cookies.get(TOKEN_KEY)) {
+    url.pathname = HOME_URL
     return NextResponse.redirect(url)
   }
 }

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -114,7 +114,7 @@ const CreateMenu = () => {
         <SubmitButton
           color={'#fff'}
           backgroundColor={'#000'}
-          disabled={checkButtonDisabled()}
+          disabled={checkButtonDisabled() && true}
           onClick={handleEditSubmit}
         >
           등록 하기

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -32,8 +32,11 @@ const CreateMenu = () => {
   const [expectedPrice, setExpectedPrice] = useState(0)
   const [isPriceButtonClicked, setIsPriceButtonClicked] = useState(false)
 
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
   const checkButtonDisabled = () => {
     return !(
+      !isSubmitted &&
       franchiseId &&
       title &&
       originalTitle &&
@@ -52,6 +55,7 @@ const CreateMenu = () => {
   }
 
   const handleEditSubmit = async () => {
+    setIsSubmitted(true)
     setOptionList(
       optionList.filter((option) => option.name && option.description)
     )
@@ -114,7 +118,7 @@ const CreateMenu = () => {
         <SubmitButton
           color={'#fff'}
           backgroundColor={'#000'}
-          disabled={checkButtonDisabled() && true}
+          disabled={checkButtonDisabled()}
           onClick={handleEditSubmit}
         >
           등록 하기

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -114,17 +114,7 @@ const CreateMenu = () => {
         <SubmitButton
           color={'#fff'}
           backgroundColor={'#000'}
-          disabled={
-            !(
-              franchiseId &&
-              title &&
-              originalTitle &&
-              optionList.filter((option) => option.name && option.description)
-                .length &&
-              tasteIdList.length &&
-              (isPriceButtonClicked || expectedPrice > 0)
-            )
-          }
+          disabled={checkButtonDisabled()}
           onClick={handleEditSubmit}
         >
           등록 하기

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -27,8 +27,8 @@ const EditMenu = () => {
   const router = useRouter()
   const { id } = router.query
   const user = useRecoilValue(currentUser)
-  const { mutate, isLoading } = useChangeMenu()
-  const { data: menuData } = useMenu(Number(id))
+  const { mutate, isLoading: changeMenuLoading } = useChangeMenu()
+  const { data: menuData, isLoading: getMenuLoading } = useMenu(Number(id))
   useEffect(() => {
     if (menuData) {
       if (menuData.author.id !== user.id) {
@@ -54,11 +54,13 @@ const EditMenu = () => {
   const [optionList, setOptionList] = useState<Option[]>([])
   const [expectedPrice, setExpectedPrice] = useState(0)
   const [isPriceButtonClicked, setIsPriceButtonClicked] = useState(false)
-
   const [tasteIdList, setTasteIdList] = useState<number[]>([])
+
+  const [isSubmitted, setIsSubmitted] = useState(false)
 
   const checkButtonDisabled = () => {
     return !(
+      !isSubmitted &&
       franchiseId &&
       title &&
       originalTitle &&
@@ -97,6 +99,7 @@ const EditMenu = () => {
   }
 
   const handleEditSubmit = (e: React.FormEvent<HTMLButtonElement>) => {
+    setIsSubmitted(true)
     const data = {
       franchiseId,
       title,
@@ -119,7 +122,7 @@ const EditMenu = () => {
 
   return (
     <FlexContainer>
-      {isLoading ? <Spinner /> : ''}
+      {changeMenuLoading || getMenuLoading ? <Spinner /> : ''}
       <ImageUploaderWrapper>
         <ImageUploader
           value={menuData?.image}
@@ -144,7 +147,7 @@ const EditMenu = () => {
       <SubmitButton
         color={'#fff'}
         backgroundColor={'#000'}
-        disabled={checkButtonDisabled() && true}
+        disabled={checkButtonDisabled()}
         onClick={handleEditSubmit}
       >
         수정 하기

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -144,7 +144,7 @@ const EditMenu = () => {
       <SubmitButton
         color={'#fff'}
         backgroundColor={'#000'}
-        disabled={checkButtonDisabled()}
+        disabled={checkButtonDisabled() && true}
         onClick={handleEditSubmit}
       >
         수정 하기

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -11,7 +11,6 @@ import { InputList } from '@components/create-menu/InputList'
 import { useRecoilValue } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 
-import { getToken } from '@utils/cookie'
 import Spinner from '@components/Spinner'
 export interface InputListType {
   franchiseId: number


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #216

## 📌 기능 설명
느린 3g환경에서 로딩이 끝났을 때에도 잠깐 생성 / 수정 페이지가 보이는데, 이때 클릭을 하면 여러번 api가 불러와집니다.

## 👩‍💻 요구 사항과 구현 내용
state를 둬서 한번만 누룰 수 있도록 만들었습니다. 

## 구현 결과

<!-- 이미지를 첨부해주세요. -->
