### PR TITLE
feat: 라우팅 로딩 처리를 위한 useRouterChangeHook 생성

### DIFF
--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/router'
 import styled from '@emotion/styled'
 import TagContainer from '@components/TagContainer'
@@ -21,6 +21,18 @@ export interface InputListType {
 const CreateMenu = () => {
   // 필드 값
   const router = useRouter()
+  const [isRouterChange, setIsRouterChange] = useState(false)
+  const handleRouteChangeStart = useCallback(() => {
+    setIsRouterChange((isChange) => !isChange)
+  }, [])
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+    }
+  }, [handleRouteChangeStart, router.events])
+
   const { mutate, isLoading } = usePostMenu()
 
   const [file, setFile] = useState<File | null>(null)
@@ -97,7 +109,7 @@ const CreateMenu = () => {
   return (
     <>
       <FlexContainer>
-        {isLoading ? <Spinner /> : ''}
+        {isRouterChange || isLoading ? <Spinner /> : ''}
         <ImageUploaderWrapper>
           <ImageUploader isDeletable={true} onChange={handleImageChange} />
         </ImageUploaderWrapper>

--- a/pages/create-menu/index.tsx
+++ b/pages/create-menu/index.tsx
@@ -8,6 +8,7 @@ import { Option } from '@customTypes/index'
 import { usePostMenu } from '@hooks/mutations/usePostMenuMutation'
 import { InputList } from '@components/create-menu/InputList'
 import Spinner from '@components/Spinner'
+import useRouterLoading from '@hooks/useRouterLoading'
 
 export interface InputListType {
   franchiseId: number
@@ -21,18 +22,7 @@ export interface InputListType {
 const CreateMenu = () => {
   // 필드 값
   const router = useRouter()
-  const [isRouterChange, setIsRouterChange] = useState(false)
-  const handleRouteChangeStart = useCallback(() => {
-    setIsRouterChange((isChange) => !isChange)
-  }, [])
-
-  useEffect(() => {
-    router.events.on('routeChangeStart', handleRouteChangeStart)
-    return () => {
-      router.events.off('routeChangeStart', handleRouteChangeStart)
-    }
-  }, [handleRouteChangeStart, router.events])
-
+  const isRouterLoading = useRouterLoading()
   const { mutate, isLoading } = usePostMenu()
 
   const [file, setFile] = useState<File | null>(null)
@@ -109,7 +99,7 @@ const CreateMenu = () => {
   return (
     <>
       <FlexContainer>
-        {isRouterChange || isLoading ? <Spinner /> : ''}
+        {isRouterLoading || isLoading ? <Spinner /> : ''}
         <ImageUploaderWrapper>
           <ImageUploader isDeletable={true} onChange={handleImageChange} />
         </ImageUploaderWrapper>

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import styled from '@emotion/styled'
 import TagContainer from '@components/TagContainer'
 import ImageUploader from '@components/ImageUploader'
@@ -25,6 +25,19 @@ const EditMenu = () => {
   // 필드 값
 
   const router = useRouter()
+
+  const [isRouterChange, setIsRouterChange] = useState(false)
+  const handleRouteChangeStart = useCallback(() => {
+    setIsRouterChange((r) => !r)
+  }, [])
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+    }
+  }, [handleRouteChangeStart, router.events])
+
   const { id } = router.query
   const user = useRecoilValue(currentUser)
   const { mutate, isLoading: changeMenuLoading } = useChangeMenu()
@@ -122,7 +135,7 @@ const EditMenu = () => {
 
   return (
     <FlexContainer>
-      {changeMenuLoading || getMenuLoading ? <Spinner /> : ''}
+      {isRouterChange || changeMenuLoading || getMenuLoading ? <Spinner /> : ''}
       <ImageUploaderWrapper>
         <ImageUploader
           value={menuData?.image}

--- a/pages/edit-menu/[id].tsx
+++ b/pages/edit-menu/[id].tsx
@@ -12,6 +12,7 @@ import { useRecoilValue } from 'recoil'
 import { currentUser } from '@recoil/currentUser'
 
 import Spinner from '@components/Spinner'
+import useRouterLoading from '@hooks/useRouterLoading'
 export interface InputListType {
   franchiseId: number
   title: string
@@ -26,17 +27,7 @@ const EditMenu = () => {
 
   const router = useRouter()
 
-  const [isRouterChange, setIsRouterChange] = useState(false)
-  const handleRouteChangeStart = useCallback(() => {
-    setIsRouterChange((r) => !r)
-  }, [])
-
-  useEffect(() => {
-    router.events.on('routeChangeStart', handleRouteChangeStart)
-    return () => {
-      router.events.off('routeChangeStart', handleRouteChangeStart)
-    }
-  }, [handleRouteChangeStart, router.events])
+  const isRouterLoading = useRouterLoading()
 
   const { id } = router.query
   const user = useRecoilValue(currentUser)
@@ -135,7 +126,11 @@ const EditMenu = () => {
 
   return (
     <FlexContainer>
-      {isRouterChange || changeMenuLoading || getMenuLoading ? <Spinner /> : ''}
+      {isRouterLoading || changeMenuLoading || getMenuLoading ? (
+        <Spinner />
+      ) : (
+        ''
+      )}
       <ImageUploaderWrapper>
         <ImageUploader
           value={menuData?.image}

--- a/src/hooks/useRouterLoading.ts
+++ b/src/hooks/useRouterLoading.ts
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router'
+import { useState, useCallback, useEffect } from 'react'
+
+function useRouterLoading() {
+  const router = useRouter()
+  const [isRouterChange, setIsRouterChange] = useState(false)
+  const handleRouteChangeStart = useCallback(() => {
+    setIsRouterChange((isChange) => !isChange)
+  }, [])
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+    }
+  }, [handleRouteChangeStart, router.events])
+
+  return isRouterChange
+}
+
+export default useRouterLoading


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명
- 라우팅 시 로딩을 처리하기 위해 현재 라우팅 중인지 아닌지를 반환하는  hook을 만들었습니다. 
## 👩‍💻 요구 사항과 구현 내용


```js
function useRouterLoading() {
  const router = useRouter()
  const [isRouterChange, setIsRouterChange] = useState(false)
  const handleRouteChangeStart = useCallback(() => {
    setIsRouterChange((isChange) => !isChange)
  }, [])

  useEffect(() => {
    router.events.on('routeChangeStart', handleRouteChangeStart)
    return () => {
      router.events.off('routeChangeStart', handleRouteChangeStart)
    }
  }, [handleRouteChangeStart, router.events])

  return isRouterChange
}

export default useRouterLoading
```

사용하는 쪽에서는 boolean 값을 반환받아 스피너 컴포넌트와 함께 조건문으로 사용하실 수 있습니다.

```js
  const isRouterLoading = useRouterLoading()
 return ( ... 
 {isRouterLoading ? <Spinner /> : ''} 
 ... )
```

<!-- 요구 사항과 실제 구현 내용을 작성해 주세요 -->

## 구현 결과
현재 create page, edit page에 훅을 적용시켜서 다른 페이지로 이동할 때 로딩 처리가 보여집니다. 

## 논의할 점
로딩 시 뜨는데, 빠른 네트워크 환경에서는 아주 잠깐 뜨고 사라지기 때문에 오히려 깜빡거림이 있어서 안좋ㅇ은 것 같기도  합니다... 한번 확인해주시면 감사하겠습니다! 