### PR TITLE
feat: 메인 페이지 앱 소개 배너 구현

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,12 @@ import useIntersectionObserver from '@hooks/useIntersectionObserver'
 import MenuCardList from '@components/MenuCardList'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
 import SkeletonCardList from '@components/SkeletonCardList'
+import BannerCard from '@components/BannerCard'
+import { MAIN_BANNER_IMAGE } from '@constants/image'
+import styled from '@emotion/styled'
+import { useState } from 'react'
+
+const BANNER_TEXT = '나만의 커스텀 메뉴를 공유해보세요'
 
 const Home: NextPage = () => {
   const { menuList, isLoading, fetchNextPage } = useSearchMenuList({
@@ -10,6 +16,8 @@ const Home: NextPage = () => {
     limit: 10,
     franchiseId: 0
   })
+
+  const [isBannerClosed, setIsBannerClosed] = useState(true)
 
   const ref = useIntersectionObserver(
     async (entry, observer) => {
@@ -21,6 +29,16 @@ const Home: NextPage = () => {
 
   return (
     <>
+      {isBannerClosed && (
+        <BannerContainer>
+          <BannerCard
+            src={MAIN_BANNER_IMAGE}
+            isClosed={false}
+            content={BANNER_TEXT}
+          />
+        </BannerContainer>
+      )}
+
       {isLoading ? (
         <SkeletonCardList size={4} />
       ) : (
@@ -29,5 +47,9 @@ const Home: NextPage = () => {
     </>
   )
 }
+
+const BannerContainer = styled.div`
+  margin: 1rem 0;
+`
 
 export default Home

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,9 +6,17 @@ import SkeletonCardList from '@components/SkeletonCardList'
 import BannerCard from '@components/BannerCard'
 import { MAIN_BANNER_IMAGE } from '@constants/image'
 import styled from '@emotion/styled'
-import { useState } from 'react'
-
-const BANNER_TEXT = '나만의 커스텀 메뉴를 공유해보세요'
+import { useState, useEffect } from 'react'
+import {
+  BANNER_CLOSE,
+  BANNER_OPEN,
+  BANNER_STORAGE_KEY,
+  BANNER_TEXT
+} from '@constants/mainPage'
+import {
+  getSessionStorageItem,
+  setSessionStorageItem
+} from '@utils/sessionStorage'
 
 const Home: NextPage = () => {
   const { menuList, isLoading, fetchNextPage } = useSearchMenuList({
@@ -17,7 +25,11 @@ const Home: NextPage = () => {
     franchiseId: 0
   })
 
-  const [isBannerClosed, setIsBannerClosed] = useState(true)
+  const [bannerState, setBannerState] = useState(BANNER_CLOSE)
+
+  useEffect(() => {
+    setBannerState(getSessionStorageItem(BANNER_STORAGE_KEY) || BANNER_OPEN)
+  }, [])
 
   const ref = useIntersectionObserver(
     async (entry, observer) => {
@@ -27,14 +39,20 @@ const Home: NextPage = () => {
     { threshold: 0.5 }
   )
 
+  const handleBannerClose = () => {
+    setBannerState(BANNER_CLOSE)
+    setSessionStorageItem(BANNER_STORAGE_KEY, BANNER_CLOSE)
+  }
+
   return (
     <>
-      {isBannerClosed && (
+      {bannerState === BANNER_OPEN && (
         <BannerContainer>
           <BannerCard
             src={MAIN_BANNER_IMAGE}
             isClosed={false}
             content={BANNER_TEXT}
+            onClose={handleBannerClose}
           />
         </BannerContainer>
       )}

--- a/src/components/BannerCard.tsx
+++ b/src/components/BannerCard.tsx
@@ -1,0 +1,66 @@
+import { SPINNER_LOGO } from '@constants/image'
+import theme from '@constants/theme'
+import styled from '@emotion/styled'
+import Image from 'next/image'
+import { IoCloseSharp } from 'react-icons/io5'
+
+interface Props {
+  content: string
+  src: string
+  isClosed: boolean
+}
+
+const BannerCard = ({ content, src }: Props) => {
+  return (
+    <Container>
+      <BannerLeft>
+        <Image src={SPINNER_LOGO} width={60} height={16} alt="로고" />
+        <Content>{content}</Content>
+      </BannerLeft>
+      <Image src={src} width={150} height={150} alt="메인배너" />
+      <CloseButton />
+    </Container>
+  )
+}
+
+const CloseButton = styled(IoCloseSharp)`
+  position: absolute;
+  font-size: 1.6rem;
+  font-weight: 700;
+  top: 1rem;
+  right: 1rem;
+  color: ${theme.color.fontLight};
+  cursor: pointer;
+`
+
+const BannerLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  height: 100%;
+`
+
+const Content = styled.div`
+  font-size: 1.8rem;
+  font-weight: 700;
+  width: 16rem;
+  line-height: 2.8rem;
+`
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border-radius: 1rem;
+  padding: 2rem;
+
+  height: 18rem;
+
+  background: #ffffff;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+`
+
+export default BannerCard

--- a/src/components/BannerCard.tsx
+++ b/src/components/BannerCard.tsx
@@ -8,9 +8,10 @@ interface Props {
   content: string
   src: string
   isClosed: boolean
+  onClose: () => void
 }
 
-const BannerCard = ({ content, src }: Props) => {
+const BannerCard = ({ content, src, onClose }: Props) => {
   return (
     <Container>
       <BannerLeft>
@@ -18,7 +19,7 @@ const BannerCard = ({ content, src }: Props) => {
         <Content>{content}</Content>
       </BannerLeft>
       <Image src={src} width={150} height={150} alt="메인배너" />
-      <CloseButton />
+      <CloseButton onClick={onClose} />
     </Container>
   )
 }

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -6,7 +6,10 @@ export const BIG_LOGO =
   'https://user-images.githubusercontent.com/79133602/184341912-1625fb09-1af2-41a0-b16e-6a2f76db30ef.svg'
 export const NO_IMAGE =
   'https://user-images.githubusercontent.com/81891292/184542528-0d65f560-293e-45d5-a8dd-5d390ebeba85.png'
-
+export const MAIN_BANNER_IMAGE =
+  'https://user-images.githubusercontent.com/81891292/184827094-64bbedaa-d763-42d4-9ada-75ff55cc138c.png'
+export const SPINNER_LOGO =
+  'https://user-images.githubusercontent.com/81891292/184830621-f244b579-038f-41d4-a3c8-4a1f0c7bcbb1.png'
 export const LOGOS = {
   공차: 'https://user-images.githubusercontent.com/79133602/184493341-8981fc37-8867-4756-a09d-cd667548492f.png',
   도미노피자:

--- a/src/constants/mainPage.ts
+++ b/src/constants/mainPage.ts
@@ -1,0 +1,4 @@
+export const BANNER_TEXT = '나만의 커스텀 메뉴를 공유해보세요'
+export const BANNER_STORAGE_KEY = 'bannerState'
+export const BANNER_OPEN = 'open'
+export const BANNER_CLOSE = 'close'

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -1,0 +1,9 @@
+export const getSessionStorageItem = (key: string) => {
+  if (typeof window === undefined) return
+  return window.sessionStorage.getItem(key)
+}
+
+export const setSessionStorageItem = (key: string, value: string) => {
+  if (typeof window === undefined) return
+  window.sessionStorage.setItem(key, value)
+}


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명

- 메인 페이제에 앱 소개 배너를 구현했습니다

## 👩‍💻 요구 사항과 구현 내용

- 배너를 닫은 상태를 sessionStorage를 통해 브라우저가 켜있을 동안 유지되도록 구현했습니다.

## 구현 결과

![banner](https://user-images.githubusercontent.com/81891292/184852646-d56d73fd-c121-476f-bcb7-0fb6731be220.PNG)

