### PR TITLE
refactor: MenuCard 이미지 LazyLoading 적용 및 메인페이지 400에러 해결

### DIFF
--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -12,6 +12,20 @@ import {
 import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
 
+/**
+ *
+ * 상태가 필요한 부분?
+ * queryString으로 검색 조건을 전부 맞추면 어떨까?
+ *
+ *
+ *
+ * Submit 발생 부
+ * 1. 정렬 선택 : url 바꾸고 나서
+ *
+ * 1. 정렬 => 선택시 상태변경이 아니라 라우터 변경
+ * 2. 맛태그 =>
+ */
+
 const Search = () => {
   const router = useRouter()
   const id = parseInt(router.query.category as string)

--- a/src/components/common/MenuCard.tsx
+++ b/src/components/common/MenuCard.tsx
@@ -5,6 +5,8 @@ import { BiComment } from 'react-icons/bi'
 import { RefObject } from 'react'
 import theme from '@constants/theme'
 import { NO_IMAGE } from '@constants/image'
+import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
+import { useState } from 'react'
 
 interface Props {
   title: string
@@ -31,9 +33,19 @@ const MenuCard = ({
     imageUrl = NO_IMAGE
   }
 
+  const [isObserved, setIsObserved] = useState(false)
+
+  const imageRef = useIntersectionObserver(
+    async (entry, observer) => {
+      observer.unobserve(entry.target)
+      setIsObserved(true)
+    },
+    { threshold: 0.5, rootMargin: '-100px 0px' }
+  )
+
   return (
     <CardContainer ref={divRef}>
-      <Img src={imageUrl} />
+      <Img src={isObserved ? imageUrl : NO_IMAGE} ref={imageRef} />
       <CardInfo>
         <CardHeader>
           <Franchise>{franchise}</Franchise>

--- a/src/components/common/MenuCard.tsx
+++ b/src/components/common/MenuCard.tsx
@@ -40,7 +40,7 @@ const MenuCard = ({
       observer.unobserve(entry.target)
       setIsObserved(true)
     },
-    { threshold: 0.5, rootMargin: '-100px 0px' }
+    { threshold: 0.5, rootMargin: '-65px 0px' }
   )
 
   return (
@@ -53,7 +53,11 @@ const MenuCard = ({
         </CardHeader>
         <CardFooter>
           <UserInfoWrapper>
-            <Avatar size={2.4} src={avatarImageUrl} isLoading={false} />
+            <Avatar
+              size={2.4}
+              src={isObserved ? avatarImageUrl : undefined}
+              isLoading={false}
+            />
             <Author>{author}</Author>
           </UserInfoWrapper>
           <PostInfoWrapper>

--- a/src/hooks/queries/useSearchMenuList.ts
+++ b/src/hooks/queries/useSearchMenuList.ts
@@ -30,7 +30,7 @@ const getMenuList = async (params: searchParams) => {
 export const useSearchMenuList = (params: searchParams) => {
   const { keyword, tasteIdList, sort, limit, franchiseId, offset } = params
 
-  const { data, isLoading, error, fetchNextPage, refetch } = useInfiniteQuery<
+  const { data, isLoading, error, fetchNextPage } = useInfiniteQuery<
     searchResponse,
     Error
   >(
@@ -55,17 +55,10 @@ export const useSearchMenuList = (params: searchParams) => {
     .flat()
     .filter((val) => !!val)
 
-  refetch({
-    refetchPage: (page, index) => {
-      return true
-    }
-  })
-
   return {
     menuList,
     isLoading,
     error,
-    fetchNextPage,
-    refetch
+    fetchNextPage
   }
 }

--- a/src/hooks/queries/useSearchMenuList.ts
+++ b/src/hooks/queries/useSearchMenuList.ts
@@ -34,7 +34,7 @@ export const useSearchMenuList = (params: searchParams) => {
     searchResponse,
     Error
   >(
-    ['myMenuList', keyword, tasteIdList, sort, limit, offset, franchiseId],
+    ['menuList', keyword, tasteIdList, sort, limit, offset, franchiseId],
     ({ pageParam = { offset: 0, limit: 10 } }) => {
       return getMenuList({
         ...params,

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -32,7 +32,7 @@ export const useSearchMyMenuList = (params: searchParams) => {
   const { keyword, tasteIdList, sort, limit, offset, accountId, option } =
     params
 
-  const { data, isLoading, error, fetchNextPage, refetch } = useInfiniteQuery<
+  const { data, isLoading, error, fetchNextPage } = useInfiniteQuery<
     searchResponse,
     Error
   >(
@@ -64,12 +64,6 @@ export const useSearchMyMenuList = (params: searchParams) => {
     .map((value) => value?.menu)
     .flat()
     .filter((val) => !!val)
-
-  refetch({
-    refetchPage: (page, index) => {
-      return true
-    }
-  })
 
   return {
     menuList,


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #252

## 📌 기능 설명

- 화면에 카드가 들어왔을 때만 정적 자원 이미지를 요청할 수 있도록 구현했습니다
- 또한 기존 페이지 접속시 400에러 발생 부분을 수정했습니다

## 👩‍💻 요구 사항과 구현 내용

- useIntersectionObserver를 통해 화면내부에 감지되었을때 메뉴 카드 상태를 변경해 이미지 주소를 주입하도록 구현했습니다.
- 400에러 해결을 위해 메뉴 리스트를 불러오는 hook에 refetch 부분을 제거했습니다.


