### PR TITLE
refactor: 헤더 UI 수정

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -4,7 +4,13 @@ import { useRouter } from 'next/router'
 import { IoChevronBackSharp } from 'react-icons/io5'
 import { FiLogIn, FiUser } from 'react-icons/fi'
 import Link from 'next/link'
-import { MYINFO_URL, LOGIN_URL, USER_URL, HOME_URL } from '@constants/pageUrl'
+import {
+  MYINFO_URL,
+  LOGIN_URL,
+  USER_URL,
+  HOME_URL,
+  DETAIL_URL
+} from '@constants/pageUrl'
 import { getToken } from '@utils/cookie'
 import { SMALL_LOGO } from '@constants/image'
 import Image from 'next/image'
@@ -20,7 +26,6 @@ export const Header = () => {
   const router = useRouter()
   const { pathname } = router
   const [title, setTitle] = useState('')
-
   const [token, setToken] = useState('')
 
   useEffect(() => {
@@ -38,6 +43,9 @@ export const Header = () => {
     if (pathname.includes(USER_URL)) {
       setTitle(TITLE_USER)
     }
+    if (pathname.includes(DETAIL_URL)) {
+      setTitle(' ')
+    }
   }, [])
 
   useEffect(() => {
@@ -47,7 +55,7 @@ export const Header = () => {
 
   return (
     <HeaderContainer>
-      <StyledBackIcon onClick={onClickPrev} />
+      {pathname !== HOME_URL && <StyledBackIcon onClick={onClickPrev} />}
       {title ? (
         <Title>{title}</Title>
       ) : (


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #245 

## 📌 기능 설명

헤더 수정사항 반영

## 👩‍💻 요구 사항과 구현 내용
- [x] 네비게이션 첫 페이지에서는 뒤로가기가 존재하지 않아야 할 것
- [x]  뒤로가기는 네비게이션의 스택이 쌓이는 디테일 페이지에서부터
- [x]  디테일페이지 등에서는 뒤로가기와 홈 두개가 같이 존재하는 형태로 만들고, 가운데 앱의 로고는 제외한다던지 하는 UI적 관점은 있을 수 있을 것 같습니다.
