### PR TITLE
refactor: user.id 조건문 변경 및 불필요한 router 제거

### DIFF
--- a/pages/myInfo/password.tsx
+++ b/pages/myInfo/password.tsx
@@ -73,11 +73,7 @@ const PasswordEditPage = () => {
     const isError = Object.keys(errors).some(
       (key) => errors[key as keyof typeof errors] !== ''
     )
-    if (!user.id) {
-      router.replace('/login')
-      return
-    }
-    if (password && !isError) {
+    if (user.id && password && !isError) {
       patchPassword({ userId: user.id, password })
       router.back()
     }

--- a/src/components/myInfo/UserProfile.tsx
+++ b/src/components/myInfo/UserProfile.tsx
@@ -32,7 +32,6 @@ const UserProfile = () => {
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [user, setUser] = useRecoilState<User>(currentUser)
   const [isReset, setIsReset] = useState(true)
-  const router = useRouter()
   const { mutate: patchImage } = useChangeImageMutation()
   const { mutate: patchNickName } = useChangeNickNameMutation()
 
@@ -59,11 +58,9 @@ const UserProfile = () => {
       reader.onload = () => {
         setUser({ ...user, image: String(reader.result) })
       }
-      if (!user.id) {
-        router.replace('/login')
-        return
+      if (user.id) {
+        patchImage({ userId: user.id, image: imageFile })
       }
-      patchImage({ userId: user.id, image: imageFile })
     }
     setIsProfileModalOpen(false)
   }, [imageFile, patchImage, user, setUser])
@@ -91,12 +88,7 @@ const UserProfile = () => {
       return
     }
 
-    if (!user.id) {
-      router.replace('/login')
-      return
-    }
-
-    if (!error) {
+    if (user.id && !error) {
       patchNickName({ userId: user.id, nickName: nickName })
       setUser({ ...user, nickName: nickName })
       setIsNameEditorOpen(false)


### PR DESCRIPTION
## 📌 기능 설명

user.id 조건문에 대한 멘토님 의견 반영

## 👩‍💻 요구 사항과 구현 내용

![image](https://user-images.githubusercontent.com/79133602/187375408-9f0aa29c-4b17-42f4-bb9c-79c6958266a3.png)

![image](https://user-images.githubusercontent.com/79133602/187374692-23b66a49-25d3-4115-9fd4-77d3e2269df0.png)

- user의 id 타입이 number | null이라서 해당 조건이 없으면 타입 에러가 나기에 조건문은 두되 rotuer는 제거
![image](https://user-images.githubusercontent.com/79133602/187374981-f03dcd6b-3534-42d7-8478-2b60666e0806.png)

