### PR TITLE
fix: 상세페이지 UX 개선

### DIFF
--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, useCallback, useRef, useState } from 'react'
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import styled from '@emotion/styled'
 import { usePostCommentMutation } from '@hooks/mutations/usePostCommentMutation'
 import { Modal } from '@components/common'
@@ -13,10 +19,14 @@ interface Props {
 
 const CommentInput = ({ menuId, userId }: Props) => {
   const [comment, setComment] = useState('')
-  const [isLoggedIn] = useState(!!userId)
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { mutate: postComment } = usePostCommentMutation()
+
+  useEffect(() => {
+    setIsLoggedIn(!!userId)
+  }, [userId])
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     if (textareaRef.current === null) {

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -27,7 +27,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
     setComment(e.target.value)
   }, [])
 
-  const handleAddButtonClick = () => {
+  const addComment = () => {
     if (!userId) {
       return
     }
@@ -50,6 +50,16 @@ const CommentInput = ({ menuId, userId }: Props) => {
     )
   }
 
+  const handleAddClick = () => {
+    addComment()
+  }
+
+  const handleEnterPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') {
+      addComment()
+    }
+  }
+
   return (
     <CommentWriteContainer>
       <Textarea
@@ -59,8 +69,9 @@ const CommentInput = ({ menuId, userId }: Props) => {
         }
         maxLength={80}
         onChange={handleChange}
+        onKeyDown={handleEnterPress}
       />
-      <AddCommentButton onClick={handleAddButtonClick}>등록</AddCommentButton>
+      <AddCommentButton onClick={handleAddClick}>등록</AddCommentButton>
     </CommentWriteContainer>
   )
 }

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 import { usePostCommentMutation } from '@hooks/mutations/usePostCommentMutation'
+import { Modal } from '@components/common'
 
 const GUEST_INPUT_PLACEHOLDER = '로그인 후 작성해주세요(최대 80자).'
 const LOGGEDIN_INPUT_PLACEHOLDER = '댓글을 입력해주세요.'
@@ -12,8 +13,9 @@ interface Props {
 
 const CommentInput = ({ menuId, userId }: Props) => {
   const [comment, setComment] = useState('')
-  const [isLoggedIn] = useState(userId)
+  const [isLoggedIn] = useState(!!userId)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
   const { mutate: postComment } = usePostCommentMutation()
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -28,6 +30,10 @@ const CommentInput = ({ menuId, userId }: Props) => {
   }, [])
 
   const addComment = () => {
+    if (comment.replace(/\s/g, '').length === 0) {
+      return
+    }
+
     if (!userId) {
       return
     }
@@ -60,8 +66,18 @@ const CommentInput = ({ menuId, userId }: Props) => {
     }
   }
 
+  const handleTextareaClick = (isLoggedIn: boolean) => {
+    if (!isLoggedIn) {
+      setIsModalOpen(true)
+    }
+  }
+
+  const handleModalClose = () => {
+    setIsModalOpen(false)
+  }
+
   return (
-    <CommentWriteContainer>
+    <CommentWriteContainer onClick={() => handleTextareaClick(isLoggedIn)}>
       <Textarea
         ref={textareaRef}
         placeholder={
@@ -72,6 +88,11 @@ const CommentInput = ({ menuId, userId }: Props) => {
         onKeyDown={handleEnterPress}
       />
       <AddCommentButton onClick={handleAddClick}>등록</AddCommentButton>
+      <Modal visible={isModalOpen} onClose={handleModalClose}>
+        <ModalItem>
+          <span>로그인하세요.</span>
+        </ModalItem>
+      </Modal>
     </CommentWriteContainer>
   )
 }
@@ -114,6 +135,17 @@ const AddCommentButton = styled.button`
   background-color: black;
   margin-left: -6rem;
   cursor: pointer;
+`
+
+const ModalItem = styled(Flex)`
+  justify-content: center;
+  align-items: center;
+  height: 5rem;
+
+  & > span {
+    font-weight: 700;
+    font-size: 1.8rem;
+  }
 `
 
 export default CommentInput

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -71,7 +71,9 @@ const CommentInput = ({ menuId, userId }: Props) => {
   }
 
   const handleEnterPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter') {
+    if (e.shiftKey) {
+      return
+    } else if (e.key === 'Enter') {
       addComment()
     }
   }
@@ -100,7 +102,7 @@ const CommentInput = ({ menuId, userId }: Props) => {
       <AddCommentButton onClick={handleAddClick}>등록</AddCommentButton>
       <Modal visible={isModalOpen} onClose={handleModalClose}>
         <ModalItem>
-          <span>로그인하세요.</span>
+          <span>로그인해주세요.</span>
         </ModalItem>
       </Modal>
     </CommentWriteContainer>

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -93,7 +93,7 @@ const MenuDetail = ({ menu, userId }: Props) => {
             ) : (
               <EmptyHeart size={50} onClick={handleHeartClick} />
             )}
-            <LikesCountText clicked={isLikeClicked}>
+            <LikesCountText clicked={isLikeClicked} onClick={handleHeartClick}>
               <span>{menu.likes}</span>
             </LikesCountText>
             {menu.author.id === userId && (
@@ -236,6 +236,7 @@ const LikesCountText = styled(Flex)<{ clicked: boolean }>`
   bottom: 0.2rem;
   font-size: 1.4rem;
   font-weight: 700;
+  cursor: pointer;
 `
 
 const Dots = styled(BiDotsVerticalRounded)`


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #253 
## 📌 기능 설명

## 👩‍💻 요구 사항과 구현 내용
### 구현한 부분
- 좋아요 버튼의 숫자 부분이 기능이 작동
- 댓글 엔터치면 개행이 아닌 댓글 등록
- 로그인 안하고 댓글 달려고 시도할 시(textarea 클릭 시) 로그인 하세요 모달

### 구현하지 못한 부분
- 출력된 댓글에 개행도 인식

## 구현 결과
<img width="1440" alt="스크린샷 2022-09-01 20 46 39" src="https://user-images.githubusercontent.com/81501723/187906499-f53866ad-9a45-4e2c-8291-97389fd51fd1.png">

