### PR TITLE
refactor: 쿠키 재발급 일자 변경

### DIFF
--- a/src/recoil/currentUser.ts
+++ b/src/recoil/currentUser.ts
@@ -3,7 +3,7 @@ import { User } from '@interfaces'
 import { v1 } from 'uuid'
 import { DEFAULT_USER_IMAGE } from '@constants/image'
 import { setCookie, getCookie } from '@utils/cookie'
-import { TOKEN_EXPIRE_DATE, CURRENT_USER } from '@constants/token'
+import { REFRESH_TOKEN_EXPIRE_DATE, CURRENT_USER } from '@constants/token'
 
 export const initialUser = {
   id: null,
@@ -25,7 +25,7 @@ const makeCookieEffect =
     }
 
     onSet((newValue: User, _: any, isReset: boolean) => {
-      const expirationDate = getCookie(TOKEN_EXPIRE_DATE)
+      const expirationDate = getCookie(REFRESH_TOKEN_EXPIRE_DATE)
       isReset
         ? setCookie(key, '')
         : setCookie(key, JSON.stringify(newValue), {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -62,7 +62,7 @@ export const getTokenData = () => {
 export const setTokenData = ({ accessToken, account, refreshToken }: Data) => {
   setCookie(TOKEN_KEY, accessToken.token, {
     path: '/',
-    expires: new Date(accessToken.expirationDate)
+    expires: new Date(refreshToken.expirationDate)
   })
   setCookie(TOKEN_EXPIRE_DATE, accessToken.expirationDate, {
     path: '/',
@@ -78,7 +78,7 @@ export const setTokenData = ({ accessToken, account, refreshToken }: Data) => {
   })
   setCookie(CURRENT_USER, JSON.stringify(account), {
     path: '/',
-    expires: new Date(accessToken.expirationDate)
+    expires: new Date(refreshToken.expirationDate)
   })
 }
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -66,7 +66,7 @@ export const setTokenData = ({ accessToken, account, refreshToken }: Data) => {
   })
   setCookie(TOKEN_EXPIRE_DATE, accessToken.expirationDate, {
     path: '/',
-    expires: new Date(accessToken.expirationDate)
+    expires: new Date(refreshToken.expirationDate)
   })
   setCookie(REFRESH_TOKEN_KEY, refreshToken.token, {
     path: '/',


### PR DESCRIPTION
## 📌 기능 설명
#256 
이전 pr에서 token이 없는 경우 재발급이 안됐는데 버그를 해결했습니다.

## 버그 원인
재발급 api body에 refreshToken 뿐만 아니라 accessToken까지 보내야 해서 발생한 문제였습니다.  

## 👩‍💻 요구 사항과 구현 내용

- accessToken이 존재해야만 재발급 api를 사용할 수 있기에 accessToken가 담긴 쿠키 tastyToken, tastyToken_expire 의 expire를 refreshToken 만료일까지로 늘립니다. 

- 이러면 일정기간 접속을 안하더라도 쿠키가 남아 해당 쿠키의 값으로 accessToken이 만료됐는지, 그리고 만료됐다면 어떤 토큰을 넘길 지 알 수 있습니다. 



