### PR TITLE
feat: 상세페이지에서 뒤로가기시 스크롤 및 검색조건 유지 구현

### DIFF
--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -10,9 +10,14 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { GetServerSidePropsContext } from 'next'
 import axios from 'axios'
 import { Menu } from '@interfaces'
+import { setLocalStorageItem } from '../../src/utils/localStorage'
 
 const Detail = () => {
   const router = useRouter()
+  router.beforePopState(() => {
+    setLocalStorageItem('isPopState', 'true')
+    return true
+  })
   const id = parseInt(router.query.id as string, 10)
   const [user] = useRecoilState(currentUser)
   const { data: menu, isSuccess: isMenuSuccess } = useMenu(id)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
 import { MenuCardList, SkeletonCardList, BannerCard } from '@components/common'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
 import { MAIN_BANNER_IMAGE } from '@constants/image'
+import { getLocalStorageItem } from '../src/utils/localStorage'
 import {
   BANNER_CLOSE,
   BANNER_OPEN,
@@ -26,6 +27,8 @@ const Home: NextPage = () => {
   const [bannerState, setBannerState] = useState(BANNER_CLOSE)
 
   useEffect(() => {
+    const scrollY = getLocalStorageItem('scrollY')
+    if (scrollY !== '0') window.scrollTo(0, Number(scrollY))
     setBannerState(getSessionStorageItem(BANNER_STORAGE_KEY) || BANNER_OPEN)
   }, [])
 
@@ -44,21 +47,20 @@ const Home: NextPage = () => {
 
   return (
     <>
-      {bannerState === BANNER_OPEN && (
-        <BannerContainer>
-          <BannerCard
-            src={MAIN_BANNER_IMAGE}
-            isClosed={false}
-            content={BANNER_TEXT}
-            onClose={handleBannerClose}
-          />
-        </BannerContainer>
-      )}
-
       {isLoading ? (
         <SkeletonCardList size={4} />
       ) : (
-        <MenuCardList menuList={menuList || []} divRef={ref} />
+        <>
+          <BannerContainer>
+            <BannerCard
+              src={MAIN_BANNER_IMAGE}
+              isClosed={bannerState === BANNER_CLOSE}
+              content={BANNER_TEXT}
+              onClose={handleBannerClose}
+            />
+          </BannerContainer>
+          <MenuCardList menuList={menuList || []} divRef={ref} />
+        </>
       )}
     </>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,8 @@ import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
 import { MenuCardList, SkeletonCardList, BannerCard } from '@components/common'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
 import { MAIN_BANNER_IMAGE } from '@constants/image'
-import { getLocalStorageItem } from '../src/utils/localStorage'
+import { getLocalStorageItem } from '@utils/localStorage'
+import { setLocalStorageItem } from '../src/utils/localStorage'
 import {
   BANNER_CLOSE,
   BANNER_OPEN,
@@ -28,7 +29,13 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     const scrollY = getLocalStorageItem('scrollY')
-    if (scrollY !== '0') window.scrollTo(0, Number(scrollY))
+    const isPopState = getLocalStorageItem('isPopState')
+    if (isPopState === 'true' && scrollY !== '0') {
+      setLocalStorageItem('isPopState', 'false')
+      window.scrollTo(0, Number(scrollY))
+      setLocalStorageItem('scrollY', '0')
+    }
+
     setBannerState(getSessionStorageItem(BANNER_STORAGE_KEY) || BANNER_OPEN)
   }, [])
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,6 @@ import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
 import { MenuCardList, SkeletonCardList, BannerCard } from '@components/common'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
 import { MAIN_BANNER_IMAGE } from '@constants/image'
-import { getLocalStorageItem } from '@utils/localStorage'
-import { setLocalStorageItem } from '../src/utils/localStorage'
 import {
   BANNER_CLOSE,
   BANNER_OPEN,
@@ -17,6 +15,7 @@ import {
   getSessionStorageItem,
   setSessionStorageItem
 } from '@utils/sessionStorage'
+import { scrollRestore } from '@utils/scroll'
 
 const Home: NextPage = () => {
   const { menuList, isLoading, fetchNextPage } = useSearchMenuList({
@@ -28,14 +27,7 @@ const Home: NextPage = () => {
   const [bannerState, setBannerState] = useState(BANNER_CLOSE)
 
   useEffect(() => {
-    const scrollY = getLocalStorageItem('scrollY')
-    const isPopState = getLocalStorageItem('isPopState')
-    if (isPopState === 'true' && scrollY !== '0') {
-      setLocalStorageItem('isPopState', 'false')
-      window.scrollTo(0, Number(scrollY))
-      setLocalStorageItem('scrollY', '0')
-    }
-
+    scrollRestore()
     setBannerState(getSessionStorageItem(BANNER_STORAGE_KEY) || BANNER_OPEN)
   }, [])
 

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -29,10 +29,10 @@ const Search = () => {
   const urlOptions = convertQueryStringToObject(router.query)
 
   const [searchOptions, setSearchOptions] = useState<searchParams>({
+    ...urlOptions,
     page: 1,
     size: 10,
-    franchiseId: id,
-    ...urlOptions
+    franchiseId: id
   })
   const { franchiseList } = useFranchiseList()
   const {
@@ -83,7 +83,14 @@ const Search = () => {
       <FixedWrapper>
         <InnerWrapper>
           <FranchiseInfo franchise={getFranchise()} />
-          <SearchForm onSubmit={handleSubmit} />
+          <SearchForm
+            onSubmit={handleSubmit}
+            initialValue={{
+              sort: searchOptions.sort || 'recent',
+              keyword: searchOptions.keyword || '',
+              tasteIdList: searchOptions.tasteIdList || []
+            }}
+          />
         </InnerWrapper>
       </FixedWrapper>
       <CardListWrapper>

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -11,11 +11,11 @@ import {
 } from '@components/common'
 import { useFranchiseList } from '@hooks/queries/useFranchiseList'
 import { useSearchMenuList } from '@hooks/queries/useSearchMenuList'
-import { getLocalStorageItem, setLocalStorageItem } from '@utils/localStorage'
 import {
   convertQueryStringToObject,
   createSearchOptionParameter
 } from '@utils/queryString'
+import { scrollRestore } from '@utils/scroll'
 
 export async function getServerSideProps() {
   return {
@@ -35,20 +35,11 @@ const Search = () => {
     franchiseId: id
   })
   const { franchiseList } = useFranchiseList()
-  const {
-    menuList,
-    isLoading: isMenuListLoading,
-    fetchNextPage
-  } = useSearchMenuList(searchOptions)
+  const { menuList, isLoading, fetchNextPage } =
+    useSearchMenuList(searchOptions)
 
   useEffect(() => {
-    const scrollY = getLocalStorageItem('scrollY')
-    const isPopState = getLocalStorageItem('isPopState')
-    if (isPopState === 'true' && scrollY !== '0') {
-      setLocalStorageItem('isPopState', 'false')
-      window.scrollTo(0, Number(scrollY))
-      setLocalStorageItem('scrollY', '0')
-    }
+    scrollRestore()
   }, [])
 
   const handleSubmit = (values: SearchFormOptions) => {
@@ -94,7 +85,7 @@ const Search = () => {
         </InnerWrapper>
       </FixedWrapper>
       <CardListWrapper>
-        {isMenuListLoading ? (
+        {isLoading ? (
           <SkeletonCardList size={2} />
         ) : (
           <MenuCardList menuList={menuList || []} divRef={ref} />

--- a/pages/user/[id].tsx
+++ b/pages/user/[id].tsx
@@ -17,6 +17,7 @@ import {
 } from '@utils/queryString'
 import { getLocalStorageItem, setLocalStorageItem } from '@utils/localStorage'
 import { SkeletonFranchiseInfo } from '@components/common/SkeletonFranchiseList'
+import { scrollRestore } from '@utils/scroll'
 
 export async function getServerSideProps() {
   return {
@@ -57,13 +58,7 @@ const UserMenu = () => {
   )
 
   useEffect(() => {
-    const scrollY = getLocalStorageItem('scrollY')
-    const isPopState = getLocalStorageItem('isPopState')
-    if (isPopState === 'true' && scrollY !== '0') {
-      setLocalStorageItem('isPopState', 'false')
-      window.scrollTo(0, Number(scrollY))
-      setLocalStorageItem('scrollY', '0')
-    }
+    scrollRestore()
   }, [])
 
   const handleSubmit = (values: SearchFormOptions) => {

--- a/pages/user/[id].tsx
+++ b/pages/user/[id].tsx
@@ -3,8 +3,7 @@ import {
   Avatar,
   MenuCardList,
   SearchForm,
-  SkeletonCardList,
-  SkeletonFranchiseList
+  SkeletonCardList
 } from '@components/common'
 import styled from '@emotion/styled'
 import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
@@ -12,11 +11,18 @@ import { useSearchMyMenuList } from '@hooks/queries/useSearchMyMenuList'
 import { SearchFormOptions, searchParams } from '@interfaces'
 import { useUser } from '@hooks/queries/useUser'
 import { useRouter } from 'next/router'
+import {
+  convertQueryStringToObject,
+  createSearchOptionParameter
+} from '@utils/queryString'
+import { getLocalStorageItem, setLocalStorageItem } from '@utils/localStorage'
+import { SkeletonFranchiseInfo } from '@components/common/SkeletonFranchiseList'
 
-const SELECT_OPTION = [
-  { label: '작성한 메뉴', value: 'my' },
-  { label: '좋아요한 메뉴', value: 'like' }
-]
+export async function getServerSideProps() {
+  return {
+    props: {}
+  }
+}
 
 interface TabProps {
   selected: boolean
@@ -27,8 +33,10 @@ interface TabProps {
 const UserMenu = () => {
   const router = useRouter()
   const id = parseInt(router.query.id as string)
+  const urlOptions = convertQueryStringToObject(router.query)
+
   const [searchOptions, setSearchOptions] = useState<searchParams>({
-    option: SELECT_OPTION[0],
+    ...urlOptions,
     page: 1,
     size: 10,
     accountId: id
@@ -49,12 +57,24 @@ const UserMenu = () => {
   )
 
   useEffect(() => {
-    if (!router.isReady) return
-    setSearchOptions({ ...searchOptions, accountId: id })
-  }, [router.isReady])
+    const scrollY = getLocalStorageItem('scrollY')
+    const isPopState = getLocalStorageItem('isPopState')
+    if (isPopState === 'true' && scrollY !== '0') {
+      setLocalStorageItem('isPopState', 'false')
+      window.scrollTo(0, Number(scrollY))
+      setLocalStorageItem('scrollY', '0')
+    }
+  }, [])
 
   const handleSubmit = (values: SearchFormOptions) => {
     setSearchOptions({ ...searchOptions, ...values })
+    router.replace(
+      `${createSearchOptionParameter({
+        ...searchOptions,
+        ...values,
+        accountId: id
+      })}`
+    )
   }
 
   const handleTabClick = (e: MouseEvent<HTMLElement>) => {
@@ -64,14 +84,23 @@ const UserMenu = () => {
       sort: 'recent',
       tasteIdList: [],
       keyword: '',
-      option: { label: divElement.innerText, value: divElement.value }
+      option: divElement.value
     })
+    router.replace(
+      `${createSearchOptionParameter({
+        ...searchOptions,
+        sort: 'recent',
+        tasteIdList: [],
+        keyword: '',
+        option: divElement.value
+      })}`
+    )
   }
 
   return (
     <>
       {isUserLoading ? (
-        <SkeletonFranchiseList />
+        <SkeletonFranchiseInfo />
       ) : (
         <ProfileContainer>
           <Avatar size={7} src={user?.image} isLoading={false} />
@@ -79,21 +108,30 @@ const UserMenu = () => {
         </ProfileContainer>
       )}
       <TabContainer>
-        {SELECT_OPTION.map((selectOption, idx) => (
-          <Tab
-            key={idx}
-            selected={searchOptions.option?.value === selectOption.value}
-            value={selectOption.value}
-            onClick={handleTabClick}
-          >
-            {selectOption.label}
-          </Tab>
-        ))}
+        <Tab
+          selected={searchOptions.option === 'my'}
+          value="my"
+          onClick={handleTabClick}
+        >
+          작성한 메뉴
+        </Tab>
+        <Tab
+          selected={searchOptions.option === 'like'}
+          value="like"
+          onClick={handleTabClick}
+        >
+          좋아요한 메뉴
+        </Tab>
       </TabContainer>
       <StickyWrapper>
         <SearchForm
           onSubmit={handleSubmit}
-          searchDomain={searchOptions.option?.value}
+          searchDomain={searchOptions.option}
+          initialValue={{
+            sort: searchOptions.sort || 'recent',
+            keyword: searchOptions.keyword || '',
+            tasteIdList: searchOptions.tasteIdList || []
+          }}
         />
       </StickyWrapper>
 

--- a/src/components/common/BannerCard.tsx
+++ b/src/components/common/BannerCard.tsx
@@ -11,9 +11,9 @@ interface Props {
   onClose: () => void
 }
 
-const BannerCard = ({ content, src, onClose }: Props) => {
+const BannerCard = ({ content, src, isClosed, onClose }: Props) => {
   return (
-    <Container>
+    <Container isClosed={isClosed}>
       <BannerLeft>
         <Image src={SPINNER_LOGO} width={60} height={16} alt="로고" />
         <Content>{content}</Content>
@@ -49,17 +49,15 @@ const Content = styled.div`
   line-height: 2.8rem;
 `
 
-const Container = styled.div`
+const Container = styled.div<{ isClosed: boolean }>`
   position: relative;
-  display: flex;
+  display: ${({ isClosed }) => (isClosed ? `none` : `flex`)};
   justify-content: space-between;
   align-items: center;
   width: 100%;
   border-radius: 1rem;
   padding: 2rem;
-
   height: 18rem;
-
   background: #ffffff;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
 `

--- a/src/components/common/MenuCard.tsx
+++ b/src/components/common/MenuCard.tsx
@@ -7,6 +7,7 @@ import theme from '@constants/theme'
 import { NO_IMAGE } from '@constants/image'
 import useIntersectionObserver from '@hooks/common/useIntersectionObserver'
 import { useState } from 'react'
+import { setLocalStorageItem } from '@utils/localStorage'
 
 interface Props {
   title: string
@@ -43,8 +44,13 @@ const MenuCard = ({
     { threshold: 0.5, rootMargin: '-65px 0px' }
   )
 
+  const handleClick = () => {
+    if (typeof window === undefined) return
+    setLocalStorageItem('scrollY', window.scrollY.toString())
+  }
+
   return (
-    <CardContainer ref={divRef}>
+    <CardContainer ref={divRef} onClick={handleClick}>
       <Img src={isObserved ? imageUrl : NO_IMAGE} ref={imageRef} />
       <CardInfo>
         <CardHeader>

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -19,35 +19,39 @@ interface SortOption {
 }
 
 const PLACEHOLDER_SEARCH_INPUT = '메뉴 검색'
+const INITIAL_SEARCH_FORM_STATE = {
+  sort: 'recent',
+  keyword: '',
+  tasteIdList: []
+}
 
 const SearchForm = ({ onSubmit, searchDomain }: Props) => {
   const [modalVisible, setModalVisible] = useState(false)
-  const [tasteIdList, setTasteIdList] = useState<number[]>([])
-  const [keyword, setKeyword] = useState('')
-  const [sort, setSort] = useState('recent')
-
+  const [searchOptions, setSearchOptions] = useState<SearchFormOptions>(
+    INITIAL_SEARCH_FORM_STATE
+  )
   const inputElement = useRef<HTMLInputElement>(null)
+
   useEffect(() => {
-    setTasteIdList([])
-    setSort('recent')
-    setKeyword('')
+    setSearchOptions(INITIAL_SEARCH_FORM_STATE)
   }, [searchDomain])
 
   const handleFilterClick = () => setModalVisible(true)
   const handleModalClose = () => setModalVisible(false)
 
-  const handleSortChange = (value: string) => {
-    setSort(value)
-    onSubmit({ keyword, tasteIdList, sort: value })
+  const handleSortChange = (sort: string) => {
+    setSearchOptions({ ...searchOptions, sort })
+    onSubmit({ ...searchOptions, sort })
   }
 
   const handleKeywordChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setKeyword(e.target.value)
+    const { value: keyword } = e.target
+    setSearchOptions({ ...searchOptions, keyword })
   }
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    onSubmit({ keyword, tasteIdList, sort })
+    onSubmit(searchOptions)
     inputElement.current?.blur()
   }
 
@@ -55,7 +59,7 @@ const SearchForm = ({ onSubmit, searchDomain }: Props) => {
     <Form onSubmit={handleSubmit}>
       <SearchWrapper>
         <SearchInput
-          value={keyword}
+          value={searchOptions.keyword}
           height={5}
           type="text"
           placeholder={PLACEHOLDER_SEARCH_INPUT}
@@ -67,7 +71,10 @@ const SearchForm = ({ onSubmit, searchDomain }: Props) => {
         </SearchButton>
       </SearchWrapper>
       <OptionContainer>
-        <SortOption selectedValue={sort} onChange={handleSortChange} />
+        <SortOption
+          selectedValue={searchOptions.sort || 'recent'}
+          onChange={handleSortChange}
+        />
         <FilterWrapper onClick={handleFilterClick}>
           <FilterIcon />
           <Text>필터</Text>
@@ -75,10 +82,10 @@ const SearchForm = ({ onSubmit, searchDomain }: Props) => {
         <Modal visible={modalVisible} onClose={handleModalClose}>
           <FilterForm
             onSubmit={handleSubmit}
-            tasteIdList={tasteIdList}
+            tasteIdList={searchOptions.tasteIdList}
             onClose={handleModalClose}
             onChange={(newTagList) => {
-              setTasteIdList(newTagList)
+              setSearchOptions({ ...searchOptions, tasteIdList: newTagList })
             }}
           />
         </Modal>

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -7,7 +7,6 @@ import { useState, ChangeEvent, FormEvent, useEffect, useRef } from 'react'
 import { SearchFormOptions } from '@interfaces'
 import SortOption from './SortOption'
 import FilterForm from './FilterForm'
-
 interface Props {
   onSubmit: (values: SearchFormOptions) => void
   searchDomain?: string

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -10,6 +10,7 @@ import FilterForm from './FilterForm'
 interface Props {
   onSubmit: (values: SearchFormOptions) => void
   searchDomain?: string
+  initialValue: SearchFormOptions
 }
 
 interface SortOption {
@@ -18,21 +19,15 @@ interface SortOption {
 }
 
 const PLACEHOLDER_SEARCH_INPUT = '메뉴 검색'
-const INITIAL_SEARCH_FORM_STATE = {
-  sort: 'recent',
-  keyword: '',
-  tasteIdList: []
-}
 
-const SearchForm = ({ onSubmit, searchDomain }: Props) => {
+const SearchForm = ({ onSubmit, searchDomain, initialValue }: Props) => {
   const [modalVisible, setModalVisible] = useState(false)
-  const [searchOptions, setSearchOptions] = useState<SearchFormOptions>(
-    INITIAL_SEARCH_FORM_STATE
-  )
+  const [searchOptions, setSearchOptions] =
+    useState<SearchFormOptions>(initialValue)
   const inputElement = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    setSearchOptions(INITIAL_SEARCH_FORM_STATE)
+    setSearchOptions(initialValue)
   }, [searchDomain])
 
   const handleFilterClick = () => setModalVisible(true)

--- a/src/hooks/queries/useSearchMyMenuList.ts
+++ b/src/hooks/queries/useSearchMyMenuList.ts
@@ -37,7 +37,7 @@ export const useSearchMyMenuList = (params: searchParams) => {
   >(
     ['myMenuList', page, size, keyword, tasteIdList, sort, option, accountId],
     ({ pageParam = { page: 1, size: 10 } }) => {
-      return getMyMenuList(option?.value || 'my', {
+      return getMyMenuList(option || 'my', {
         ...params,
         page: pageParam.page,
         size: pageParam.size

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -58,7 +58,7 @@ export interface searchParams {
   keyword?: string
   sort?: string
   tasteIdList?: number[]
-  option?: { label: string; value: string }
+  option?: string
   accountId?: number
 }
 
@@ -68,4 +68,5 @@ export interface SearchFormOptions {
   sort?: string
   accountId?: number
   franchiseId?: number
+  option?: string
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -64,6 +64,8 @@ export interface searchParams {
 
 export interface SearchFormOptions {
   keyword: string
-  sort?: string
   tasteIdList: number[]
+  sort?: string
+  accountId?: number
+  franchiseId?: number
 }

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,9 @@
+export const getLocalStorageItem = (key: string) => {
+  if (typeof window === undefined) return
+  return window.localStorage.getItem(key)
+}
+
+export const setLocalStorageItem = (key: string, value: string) => {
+  if (typeof window === undefined) return
+  window.localStorage.setItem(key, value)
+}

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -24,19 +24,21 @@ export const createSearchRequestParameter = (params: searchParams) => {
 }
 
 export const createSearchOptionParameter = (params: SearchFormOptions) => {
-  const qs = `/search/${params.franchiseId}?${
-    params.sort ? `sort=${params.sort}` : `sort=recent`
-  }${params.keyword ? `&keyword=${params.keyword}` : ''}${
+  const qs = `/${params.franchiseId ? 'search' : 'user'}/${
+    params.franchiseId ? params.franchiseId : params.accountId
+  }?${params.sort ? `sort=${params.sort}` : `sort=recent`}${
+    params.keyword ? `&keyword=${params.keyword}` : ''
+  }${
     params.tasteIdList.length > 0
       ? `&tasteIdList=${params.tasteIdList.join(',')}`
       : ''
-  }`
+  }${params.option ? `&option=${params.option}` : '&option=my'}`
 
   return qs
 }
 
 export const convertQueryStringToObject = (query: ParsedUrlQuery) => {
-  const { sort, tasteIdList, keyword } = query
+  const { sort, tasteIdList, keyword, option } = query
 
   return {
     sort: typeof sort === 'string' ? sort : 'recent',
@@ -44,6 +46,7 @@ export const convertQueryStringToObject = (query: ParsedUrlQuery) => {
       typeof tasteIdList === 'string'
         ? tasteIdList.split(',').map((val) => parseInt(val))
         : undefined,
-    keyword: typeof keyword === 'string' ? keyword : undefined
+    keyword: typeof keyword === 'string' ? keyword : undefined,
+    option: typeof option === 'string' ? option : 'my'
   }
 }

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -1,4 +1,5 @@
-import { searchParams } from '@interfaces'
+import { SearchFormOptions, searchParams } from '@interfaces'
+import { ParsedUrlQuery } from 'querystring'
 
 export const createSearchRequestParameter = (params: searchParams) => {
   const requestParameter = new URLSearchParams(
@@ -20,4 +21,29 @@ export const createSearchRequestParameter = (params: searchParams) => {
     requestParameter.set('sort', `${params.sort}`)
   }
   return requestParameter
+}
+
+export const createSearchOptionParameter = (params: SearchFormOptions) => {
+  const qs = `/search/${params.franchiseId}?${
+    params.sort ? `sort=${params.sort}` : `sort=recent`
+  }${params.keyword ? `&keyword=${params.keyword}` : ''}${
+    params.tasteIdList.length > 0
+      ? `&tasteIdList=${params.tasteIdList.join(',')}`
+      : ''
+  }`
+
+  return qs
+}
+
+export const convertQueryStringToObject = (query: ParsedUrlQuery) => {
+  const { sort, tasteIdList, keyword } = query
+
+  return {
+    sort: typeof sort === 'string' ? sort : 'recent',
+    tasteIdList:
+      typeof tasteIdList === 'string'
+        ? tasteIdList.split(',').map((val) => parseInt(val))
+        : undefined,
+    keyword: typeof keyword === 'string' ? keyword : undefined
+  }
 }

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,0 +1,11 @@
+import { getLocalStorageItem, setLocalStorageItem } from './localStorage'
+
+export const scrollRestore = () => {
+  const scrollY = getLocalStorageItem('scrollY')
+  const isPopState = getLocalStorageItem('isPopState')
+  if (isPopState === 'true' && scrollY !== '0') {
+    setLocalStorageItem('isPopState', 'false')
+    window.scrollTo(0, Number(scrollY))
+    setLocalStorageItem('scrollY', '0')
+  }
+}


### PR DESCRIPTION
## ✅ 이슈 번호

resolve #250
resolve #251 
## 📌 기능 설명

상세페이지에서 뒤로가기시 검색 조건과 스크롤을 유지하도록 구현했습니다

## 👩‍💻 요구 사항과 구현 내용

- 상세페이지에서 뒤로가기 이전에 이벤트를 감지해야하기 때문에 detail 페이지에 코드를 추가했습니다.


