### PR TITLE
feat: meta description 추가, PageTitle 컴포넌트 추가

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,24 +12,28 @@ import {
 } from '@tanstack/react-query'
 import { Spinner } from '@components/common'
 import { useLoading } from '@hooks/common/useLoading'
+import PageTitle from '@components/common/PageTitle'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient())
   const [isLoading] = useLoading()
-
+  console.log(pageProps)
   return (
-    <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
-        <ThemeProvider theme={theme}>
-          <RecoilRoot>
-            <Layout>
-              {isLoading && <Spinner />}
-              <Component {...pageProps} />
-            </Layout>
-          </RecoilRoot>
-        </ThemeProvider>
-      </Hydrate>
-    </QueryClientProvider>
+    <>
+      <PageTitle />
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <ThemeProvider theme={theme}>
+            <RecoilRoot>
+              <Layout>
+                {isLoading && <Spinner />}
+                <Component {...pageProps} />
+              </Layout>
+            </RecoilRoot>
+          </ThemeProvider>
+        </Hydrate>
+      </QueryClientProvider>
+    </>
   )
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ import PageTitle from '@components/common/PageTitle'
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient())
   const [isLoading] = useLoading()
-  console.log(pageProps)
+
   return (
     <>
       <PageTitle />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -32,6 +32,7 @@ class MyDocument extends Document {
             content="https://user-images.githubusercontent.com/79133602/184350309-56e5c120-62ce-42e8-8f4f-ab767e5327b4.png"
           />
           <meta
+            name="description"
             property="og:description"
             content="커스텀메뉴 정보를 공유하는 SNS"
           />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,7 +17,7 @@ class MyDocument extends Document {
   }
   render() {
     return (
-      <Html>
+      <Html lang="ko">
         <Head>
           <link
             rel="icon"

--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -10,6 +10,7 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { GetServerSidePropsContext } from 'next'
 import axios from 'axios'
 import { Menu } from '@interfaces'
+import PageTitle from '@components/common/PageTitle'
 
 const Detail = () => {
   const router = useRouter()
@@ -23,6 +24,7 @@ const Detail = () => {
     <>
       {isMenuSuccess && (
         <>
+          <PageTitle title={`맛이 어때 | ${menu.title}`} />
           <MenuDetail menu={menu} userId={user.id} />
           <CommentInput menuId={menu.id} userId={user.id} />
         </>

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -26,48 +26,37 @@ export const Navigation = () => {
     <NavContainer>
       <NavList>
         <Link href={HOME_URL}>
-          <StyledAnchor>
-            <NavItem>
+          <NavItem>
+            <a>
               <StyledHome selected={pathname === HOME_URL} />
-            </NavItem>
-          </StyledAnchor>
+            </a>
+          </NavItem>
         </Link>
         <Link href={CREATE_MENU_URL}>
-          <StyledAnchor>
-            <NavItem>
+          <NavItem>
+            <a>
               <StyledPlus selected={pathname === CREATE_MENU_URL} />
-            </NavItem>
-          </StyledAnchor>
+            </a>
+          </NavItem>
         </Link>
         <Link href={SEARCH_URL}>
-          <StyledAnchor>
-            <NavItem>
+          <NavItem>
+            <a>
               <StyledSearch selected={pathname.includes(SEARCH_URL)} />
-            </NavItem>
-          </StyledAnchor>
+            </a>
+          </NavItem>
         </Link>
         <Link href={`${USER_URL}/${user.id}`}>
-          <StyledAnchor>
-            <NavItem>
+          <NavItem>
+            <a>
               <StyledMenu selected={pathname.includes(USER_URL)} />
-            </NavItem>
-          </StyledAnchor>
+            </a>
+          </NavItem>
         </Link>
       </NavList>
     </NavContainer>
   )
 }
-
-const StyledAnchor = styled.a`
-  width: 25%;
-  text-align: center;
-  cursor: pointer;
-  list-style: none;
-
-  &:hover {
-    color: ${(props) => props.theme.color.mainPink};
-  }
-`
 
 const NavContainer = styled.div`
   height: ${(props) => props.theme.layout.navHeight};
@@ -95,7 +84,16 @@ const NavList = styled.ul`
   align-items: center;
 `
 
-const NavItem = styled.li``
+const NavItem = styled.li`
+  width: 25%;
+  text-align: center;
+  cursor: pointer;
+  list-style: none;
+
+  &:hover {
+    color: ${(props) => props.theme.color.mainPink};
+  }
+`
 
 const StyledHome = styled(BiHomeAlt)<IconType>`
   width: 3rem;

--- a/src/components/common/PageTitle.tsx
+++ b/src/components/common/PageTitle.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head'
+
+interface Props {
+  title?: string
+}
+
+const CONSTANT_TITLE = '맛이 어때'
+
+const PageTitle = ({ title }: Props) => {
+  return (
+    <Head>
+      <title>{title || CONSTANT_TITLE}</title>
+    </Head>
+  )
+}
+
+export default PageTitle


### PR DESCRIPTION
## ✅ 이슈 번호
resolve #267
## 📌 기능 설명
- _documents.tsx의 meta 태그 중 description 추가
- 상세 페이지에서 동적으로 title 할당
## 👩‍💻 요구 사항과 구현 내용
상세 페이지 외에는 "맛이 어때"를 보여주고, 상세 페이지에선 "맛이 어때 | ${메뉴명}" 을 보여주게 했는데, 각자 페이지에서 원하는 title이 있다면 PageTitle 컴포넌트에 title prop을 넘기게 되면 덮어쓰여집니다.

## 구현 결과
<img width="168" alt="스크린샷 2022-09-13 21 42 14" src="https://user-images.githubusercontent.com/81501723/189903815-ca2d5180-bbf6-49e9-9592-da7c203e3328.png">

<img width="186" alt="스크린샷 2022-09-13 21 42 01" src="https://user-images.githubusercontent.com/81501723/189903750-c6b90ecb-e0c2-4942-9523-e7a93a3c94eb.png">
