### PR TITLE
fix: 동적 쿼리 새로고침 시 로그아웃 안되는 문제 해결

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -30,7 +30,7 @@ export const getCookie = (name: string) => {
 }
 
 export const removeCookie = (name: string) => {
-  cookies.remove(name)
+  cookies.remove(name, { path: '/' })
 }
 
 export const setToken = ({ token, expirationDate }: Token) => {


### PR DESCRIPTION
## 📌 기능 설명

동적 쿼리 새로고침 시 로그아웃 안되는 문제 해결

## 👩‍💻 요구 사항과 구현 내용

### 에러 원인
- 로그아웃 요청 성공 후 리액트 쿼리 onSuccess의 removeToken이 작동하지 않음
- 그런데 그 아래 router.reload는 작동
- 새로 고침 됐기 때문에 로그아웃 성공 메시지를 보지 못 봤던 것
- 이미 로그아웃 된 상태인데 반납한 토큰으로 요청을 하니 당연히 실패

### 해결 방법
- 모든 path에서 삭제 가능하도록 수정했더니 해결됐습니다.
공식 문서는 못 찾았는데, 동적 쿼리 새로 고침 시 무슨 일이 생기는 건지 구체적인 원인을 알면  좋을 것 같습니다.

![image](https://user-images.githubusercontent.com/79133602/190033563-683468bc-b8c7-415d-b91c-2f6cd7e48465.png)

