### PR TITLE
fix: 상세 페이지 hydration 에러 수정

### DIFF
--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -11,8 +11,6 @@ import { GetServerSidePropsContext } from 'next'
 import axios from 'axios'
 import { Menu } from '@interfaces'
 import PageTitle from '@components/common/PageTitle'
-import { setLocalStorageItem } from '../../src/utils/localStorage'
-import { useEffect } from 'react'
 
 const Detail = () => {
   const router = useRouter()
@@ -21,14 +19,6 @@ const Detail = () => {
   const { data: menu, isSuccess: isMenuSuccess } = useMenu(id)
   const { data: commentList, isSuccess: isCommentListSuccess } =
     useCommentList(id)
-
-  useEffect(() => {
-    if (!router.isReady) return
-    router.beforePopState(() => {
-      setLocalStorageItem('isPopState', 'true')
-      return true
-    })
-  }, [router, router.isReady])
 
   return (
     <>
@@ -53,14 +43,15 @@ export const getServerSideProps = async (
   const queryClient = new QueryClient()
 
   const getMenuById = async (menuId: number) => {
-    if (!context.req.cookies['tastyToken']) {
+    const cookie = context.req.cookies['tastyToken']
+    if (!cookie) {
       return
     }
 
     const { data } = await axios.get<Menu>(
       `${process.env.NEXT_PUBLIC_API_URL}/menu/${menuId}`,
       {
-        headers: { Authorization: context.req.cookies['tastyToken'] }
+        headers: { Authorization: cookie }
       }
     )
 

--- a/src/components/detail/MenuDetail.tsx
+++ b/src/components/detail/MenuDetail.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 import { Menu } from '@interfaces'
 import { Modal, Avatar } from '@components/common'
-import { BiDotsVerticalRounded, BiTrash } from 'react-icons/bi'
 import { useDeleteMenuMutation } from '@hooks/mutations/useDeleteMenuMutation'
 import { useRouter } from 'next/router'
-import { BsFillPencilFill } from 'react-icons/bs'
-import { IoMdHeart } from 'react-icons/io'
 import { usePostLikeMutation } from '@hooks/mutations/usePostLikeMutation'
 import { NO_IMAGE } from '@constants/image'
+import { IoMdHeart } from 'react-icons/io'
+import { BsFillPencilFill } from 'react-icons/bs'
+import { BiDotsVerticalRounded, BiTrash } from 'react-icons/bi'
 
 interface Props {
   menu: Menu
@@ -20,6 +20,7 @@ const MenuDetail = ({ menu, userId }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isLogInModalOpen, setIsLogInModalOpen] = useState(false)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [isOwner, setIsOwner] = useState(false)
   const { mutate: deleteMenu } = useDeleteMenuMutation()
   const { mutate: postLike, isLoading } = usePostLikeMutation({
     menuId: menu.id
@@ -28,7 +29,8 @@ const MenuDetail = ({ menu, userId }: Props) => {
 
   useEffect(() => {
     setIsLoggedIn(!!userId)
-  }, [userId])
+    setIsOwner(menu.author.id === userId)
+  }, [menu.author.id, userId])
 
   const handleUserClick = (userId: number | null) => {
     if (!userId) {
@@ -102,7 +104,7 @@ const MenuDetail = ({ menu, userId }: Props) => {
             <FranchiseText>{menu.franchise.name} </FranchiseText>
             <Title>{menu.title}</Title>
           </LeftHeader>
-          <RightHeader guest={menu.author.id !== userId}>
+          <RightHeader guest={!isOwner}>
             {isLikeClicked ? (
               <Heart size={50} onClick={handleHeartClick}></Heart>
             ) : (
@@ -111,9 +113,7 @@ const MenuDetail = ({ menu, userId }: Props) => {
             <LikesCountText clicked={isLikeClicked} onClick={handleHeartClick}>
               <span>{menu.likes}</span>
             </LikesCountText>
-            {menu.author.id === userId && (
-              <Dots size={30} onClick={handleEditMenuClick} />
-            )}
+            {isOwner && <Dots size={30} onClick={handleEditMenuClick} />}
           </RightHeader>
         </Header>
 


### PR DESCRIPTION
## ✅ 이슈 번호

## 📌 기능 설명
- 상세 페이지 새로고침 시 hydration 에러 수정

## 👩‍💻 요구 사항과 구현 내용
- 상세 페이지에서 최초 접속 후 새로 고침을 하면 server와 client의 html 구조가 다르다는 hydration error가 발생하는데, 기존의 router.isReady로 해결되지 않아 해당 부분을 지웠고 prop으로 내려주는 userId를 setState하여 isOwner로 글의 주인인지 아닌지를 판별하도록하는 로직을 추가했습니다.

## 구현 결과
### 기존 에러 발생 캡처본
<img width="1440" alt="스크린샷 2022-09-14 17 38 53" src="https://user-images.githubusercontent.com/81501723/190105208-5c747679-1843-48d7-9022-f33e881acdec.png">