### PR TITLE
fix: reissue https 에서 http 요청 에러 해결

### DIFF
--- a/src/utils/checkToken.ts
+++ b/src/utils/checkToken.ts
@@ -27,14 +27,11 @@ export const checkToken = async (config: AxiosRequestConfig) => {
     (moment(tastyToken_expire).diff(moment(), 'minutes') < 1 || !tastyToken) &&
     tastyRefreshToken
   ) {
-    const { data } = await axios.post(
-      `${process.env.NEXT_PUBLIC_API_URL}/re-issue`,
-      {
-        email: currentUser.email,
-        accessToken: tastyToken,
-        refreshToken: tastyRefreshToken
-      }
-    )
+    const { data } = await axios.post(`/api/re-issue`, {
+      email: currentUser.email,
+      accessToken: tastyToken,
+      refreshToken: tastyRefreshToken
+    })
     setToken(data)
     config.headers.Authorization = data.token
   } else {


### PR DESCRIPTION
## 📌 기능 설명
- https에서 http로 요청을 할 때 에러 해결

## 👩‍💻 요구 사항과 구현 내용
- 현재 배포서버는 https, 백엔드 서버는 http라서 직접 api를 호출하면 에러가 납니다.
- 이를 next js rewrites를 통해 우회했으나, re-issue는 /api를 붙이지 않아 rewrites가 안되고 있어서, 해당 부분 수정했습니다.
