### PR TITLE
refactor: cookie httponly 속성 true 추가

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -21,6 +21,11 @@ interface Data {
 
 const cookies = new Cookies()
 
+const defaultOptions = {
+  path: '/',
+  httpOnly: true
+}
+
 export const setCookie = (name: string, value: string, option?: any) => {
   cookies.set(name, value, { ...option })
 }
@@ -35,11 +40,11 @@ export const removeCookie = (name: string) => {
 
 export const setToken = ({ token, expirationDate }: Token) => {
   setCookie(TOKEN_KEY, token, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(expirationDate)
   })
   setCookie(TOKEN_EXPIRE_DATE, expirationDate, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(expirationDate)
   })
 }
@@ -61,23 +66,23 @@ export const getTokenData = () => {
 
 export const setTokenData = ({ accessToken, account, refreshToken }: Data) => {
   setCookie(TOKEN_KEY, accessToken.token, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(refreshToken.expirationDate)
   })
   setCookie(TOKEN_EXPIRE_DATE, accessToken.expirationDate, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(refreshToken.expirationDate)
   })
   setCookie(REFRESH_TOKEN_KEY, refreshToken.token, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(refreshToken.expirationDate)
   })
   setCookie(REFRESH_TOKEN_EXPIRE_DATE, refreshToken.expirationDate, {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(refreshToken.expirationDate)
   })
   setCookie(CURRENT_USER, JSON.stringify(account), {
-    path: '/',
+    ...defaultOptions,
     expires: new Date(refreshToken.expirationDate)
   })
 }


### PR DESCRIPTION
## 📌 기능 설명

xss 공격에 방어하기 위해 쿠키 httpOnly true를 줬습니다. 

-> preview를 보니  아래 주의 내용관련 문제가 있는 것 같습니다. vercel이 .com이 아니어서 그런 걸까요? 좀 더 확인 후 수정하도록 하겠습니다. 

## 👩‍💻 요구 사항과 구현 내용

![image](https://user-images.githubusercontent.com/79133602/193448096-267085a9-686f-4ebf-ad8e-ee384be73b37.png)

이전엔 스크립트로 쿠키에 접근 가능해서 토큰 탈취의 위험이 있었으나 httpOnly을 써서 스크립트 탈취는 불가능합니다.


### sameSite, secure 속성 제외


- sameSite: 클라이언트에서만 쿠키를 만들어 쓰기에 api로 다른 도메인에서 해당 쿠키가 전송되지 않아 사용하지 않았고 
- secure : 백엔드 서버가 http인 관계로 secure 속성을 쓸 수 없어 제외했습니다. 


### 주의 : 로컬에선 httpOnly 안돼


만약 해당 코드를 로컬에서 돌리면 쿠키가 저장되지 않습니다. httpOnly 속성 사용 시 일반적 도메인(.com)에서만 쿠키가 저장되기 때문입니다. 

[관련 stackoverflow](https://stackoverflow.com/questions/8134384/chrome-doesnt-create-cookie-for-domain-localhost-in-broken-https)