### PR TITLE
refactor: 리액트 쿼리 refetch 방지 cacheTime 수정 #104

### DIFF
--- a/src/hooks/queries/useFranchiseList.ts
+++ b/src/hooks/queries/useFranchiseList.ts
@@ -13,7 +13,8 @@ export const useFranchiseList = () => {
     ['franchises'],
     getFranchiseList,
     {
-      staleTime: Infinity
+      staleTime: Infinity,
+      cacheTime: Infinity
     }
   )
   return { franchiseList: data, isLoading }

--- a/src/hooks/queries/useTasteList.ts
+++ b/src/hooks/queries/useTasteList.ts
@@ -12,7 +12,8 @@ export const useTasteList = () => {
     ['tasteList'],
     getTasteList,
     {
-      staleTime: Infinity
+      staleTime: Infinity,
+      cacheTime: Infinity
     }
   )
   return { tasteList: data, isLoading }


### PR DESCRIPTION
## ✅ 이슈 번호

#104 에서 논의 한 내용

## 📌 기능 설명

- 앱 실행 중엔 프랜차이즈, 맛 리스트를 refetch하지 않도록 수정했습니다. 

## 👩‍💻 요구 사항과 구현 내용

찾아보니 리액트 캐싱 설정값이 다음과 같더군요. 

- staleTime: 캐싱된 값이 있을 때 refetch하지 않는 기간
- cacheTime: 캐싱 기간

현재 staleTime이 Infinity라도 cacheTime이 기본값 5분이기 때문에 해당 쿼리 인스턴스 종료 후 5분이 지나면 계속 refetch가 일어나는 것을 확인했습니다. 

```jsx
    {
      staleTime: Infinity,
      cacheTime: Infinity
    }
```
따라서 캐시타임도 Infinity로 수정했고 확인 결과 종료 후 일정 시간이 지나도 다시 refetch 하지 않았습니다. 

## 참고 

[리액트 쿼리의 캐싱](https://vaulted-count-177.notion.site/7e7dfb9454a443e68757c59c3e3c37f1)


