### PR TITLE
refactor: 뒤로가기시 스크롤 저장 구현 및 불필요 queryString 제거

### DIFF
--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -11,6 +11,8 @@ import { GetServerSidePropsContext } from 'next'
 import axios from 'axios'
 import { Menu } from '@interfaces'
 import PageTitle from '@components/common/PageTitle'
+import { useEffect } from 'react'
+import { setLocalStorageItem } from '@utils/localStorage'
 
 const Detail = () => {
   const router = useRouter()
@@ -19,6 +21,14 @@ const Detail = () => {
   const { data: menu, isSuccess: isMenuSuccess } = useMenu(id)
   const { data: commentList, isSuccess: isCommentListSuccess } =
     useCommentList(id)
+
+  useEffect(() => {
+    if (!router.isReady) return
+    router.beforePopState(() => {
+      setLocalStorageItem('isPopState', 'true')
+      return true
+    })
+  }, [router, router.isReady])
 
   return (
     <>

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -27,7 +27,6 @@ const Search = () => {
   const router = useRouter()
   const id = parseInt(router.query.category as string)
   const urlOptions = convertQueryStringToObject(router.query)
-
   const [searchOptions, setSearchOptions] = useState<searchParams>({
     ...urlOptions,
     page: 1,

--- a/pages/user/[id].tsx
+++ b/pages/user/[id].tsx
@@ -15,7 +15,6 @@ import {
   convertQueryStringToObject,
   createSearchOptionParameter
 } from '@utils/queryString'
-import { getLocalStorageItem, setLocalStorageItem } from '@utils/localStorage'
 import { SkeletonFranchiseInfo } from '@components/common/SkeletonFranchiseList'
 import { scrollRestore } from '@utils/scroll'
 
@@ -35,7 +34,6 @@ const UserMenu = () => {
   const router = useRouter()
   const id = parseInt(router.query.id as string)
   const urlOptions = convertQueryStringToObject(router.query)
-
   const [searchOptions, setSearchOptions] = useState<searchParams>({
     ...urlOptions,
     page: 1,

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -32,21 +32,27 @@ export const createSearchOptionParameter = (params: SearchFormOptions) => {
     params.tasteIdList.length > 0
       ? `&tasteIdList=${params.tasteIdList.join(',')}`
       : ''
-  }${params.option ? `&option=${params.option}` : '&option=my'}`
+  }${
+    params.option
+      ? `&option=${params.option}`
+      : params.accountId
+      ? '&option=my'
+      : ''
+  }`
 
   return qs
 }
 
 export const convertQueryStringToObject = (query: ParsedUrlQuery) => {
-  const { sort, tasteIdList, keyword, option } = query
-
+  const { sort, tasteIdList, keyword, option, id } = query
+  console.log(option, id)
   return {
     sort: typeof sort === 'string' ? sort : 'recent',
     tasteIdList:
       typeof tasteIdList === 'string'
         ? tasteIdList.split(',').map((val) => parseInt(val))
-        : undefined,
-    keyword: typeof keyword === 'string' ? keyword : undefined,
-    option: typeof option === 'string' ? option : 'my'
+        : [],
+    keyword: typeof keyword === 'string' ? keyword : '',
+    option: typeof option === 'string' ? option : id ? 'my' : ''
   }
 }


### PR DESCRIPTION


## 📌 기능 설명
#273 PR에서 detail page의 beforePopState 함수가 제거되어서 뒤로가기시 스크롤 복구가 정상 작동하지 않는 버그를 수정했습니다.
해당 부분은 렌더링과는 관련이 없는 부분이기 때문에 그대로 유지해도 무방합니다!
추가로 search 페이지에서 검색과 관련이 없는 queryString이 url에 표시되는 부분을 수정했습니다.

