### PR TITLE
feat: Slide 컴포넌트 추가

### DIFF
--- a/src/components/common/Slide.tsx
+++ b/src/components/common/Slide.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react'
+import { Menu } from '@interfaces'
+import { IoMdHeart } from 'react-icons/io'
+import { BiComment } from 'react-icons/bi'
+import { GrNext, GrPrevious } from 'react-icons/gr'
+import { GoPrimitiveDot } from 'react-icons/go'
+import Image from 'next/image'
+import styled from '@emotion/styled'
+import Link from 'next/link'
+
+interface Props {
+  menuList: Menu[]
+}
+
+const Slide = ({ menuList }: Props) => {
+  const [currentSlide, setCurrentSlide] = useState(1)
+  const [behindSlide, setBehindSlide] = useState(0)
+  const [prevX, setPrevX] = useState(0)
+  const [slideX, setSlideX] = useState(0)
+
+  const getSlideX = (event: React.TouchEvent<HTMLDivElement>) => {
+    return event.type == 'touchstart'
+      ? event.touches[0].clientX
+      : event.type == 'touchmove' || event.type == 'touchend'
+      ? event.changedTouches[0].clientX
+      : 0
+  }
+
+  const setNextSlideBehind = () => {
+    if (currentSlide >= 5) {
+      setBehindSlide(1)
+    } else {
+      setBehindSlide(currentSlide + 1)
+    }
+  }
+
+  const setPrevSlideBehind = () => {
+    if (currentSlide <= 1) {
+      setBehindSlide(5)
+    } else {
+      setBehindSlide(currentSlide - 1)
+    }
+  }
+
+  const handleSlidePrev = () => {
+    if (currentSlide <= 1) {
+      setCurrentSlide(5)
+    } else {
+      setCurrentSlide((currentSlide) => currentSlide - 1)
+    }
+  }
+
+  const handleSlideNext = () => {
+    if (currentSlide >= 5) {
+      setCurrentSlide(1)
+    } else {
+      setCurrentSlide((currentSlide) => currentSlide + 1)
+    }
+  }
+
+  const handleSelectSlide = (id: number) => {
+    setCurrentSlide(id)
+  }
+
+  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    setPrevX(getSlideX(event))
+  }
+
+  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+    const clientX = getSlideX(event)
+    const isNextMove = clientX >= prevX
+    if (isNextMove) {
+      setSlideX(clientX)
+      setNextSlideBehind()
+    } else {
+      setSlideX(-1 * prevX)
+      setPrevSlideBehind()
+    }
+  }
+
+  const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    const clientX = getSlideX(event)
+    if (clientX >= prevX) {
+      handleSlideNext()
+    } else {
+      handleSlidePrev()
+    }
+    setSlideX(0)
+  }
+
+  return (
+    <SlideContainer>
+      <>
+        {menuList.map((menu) => (
+          <SlideItem
+            key={menu.image}
+            selected={currentSlide === menu.id}
+            slideX={slideX}
+            isBehind={behindSlide === menu.id}
+          >
+            <ImageWrapper
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+            >
+              <Link href={`/detail/${menu.id}`}>
+                <a>
+                  <Image src={menu.image} alt="bannerImage" layout="fill" />
+                </a>
+              </Link>
+              <SlidePrev onClick={handleSlidePrev} />
+              <SlideNext onClick={handleSlideNext} />
+            </ImageWrapper>
+            <Info>
+              <Upper>
+                <Franchise>{menu.franchise.name}</Franchise>
+                <Flex>
+                  <Likes>
+                    <IoMdHeart />
+                    {menu.likes}
+                  </Likes>
+                  <Comments>
+                    <BiComment />
+                    {menu.comments}
+                  </Comments>
+                </Flex>
+              </Upper>
+              <MenuTitle>{menu.title}</MenuTitle>
+            </Info>
+          </SlideItem>
+        ))}
+      </>
+      <DotWrapper>
+        {menuList.map((menu) => (
+          <SlideDot
+            key={menu.id}
+            selected={currentSlide === menu.id}
+            onClick={() => handleSelectSlide(menu.id)}
+          />
+        ))}
+      </DotWrapper>
+    </SlideContainer>
+  )
+}
+
+const Flex = styled.div`
+  display: flex;
+`
+
+const SlideContainer = styled(Flex)`
+  width: 100%;
+  position: relative;
+  flex-direction: column;
+  height: 62vh;
+  border-bottom: 1px solid ${({ theme }) => theme.color.borderLight};
+`
+
+const SlideItem = styled.div<{
+  selected: boolean
+  slideX: number
+  isBehind: boolean
+}>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border-radius: 1rem;
+  overflow: hidden;
+  border-radius: 1rem;
+  position: absolute;
+  transform: translateX(${({ selected, slideX }) => selected && `${slideX}px`});
+  z-index: ${({ selected, isBehind }) => (selected ? 2 : isBehind ? 1 : 0)};
+`
+
+const ImageWrapper = styled.div`
+  position: relative;
+  cursor: pointer;
+
+  &::after {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+`
+
+const SlideNext = styled(GrNext)`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 5.6rem;
+  height: 10rem;
+  opacity: 0;
+  &:hover {
+    display: block;
+    background-color: ${({ theme }) => theme.color.borderLight};
+    opacity: 0.5;
+  }
+`
+
+const SlidePrev = styled(GrPrevious)`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 5.6rem;
+  height: 10rem;
+  opacity: 0;
+  &:hover {
+    display: block;
+    background-color: ${({ theme }) => theme.color.borderLight};
+    opacity: 0.5;
+  }
+`
+
+const Info = styled(Flex)`
+  background-color: white;
+  z-index: 2;
+  height: 7rem;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 1.6rem;
+  position: relative;
+  top: -2rem;
+`
+
+const Upper = styled(Flex)`
+  margin: 1.6rem 0.4rem 0 0;
+  justify-content: space-between;
+  font-size: 1.4rem;
+`
+
+const Franchise = styled.div`
+  color: ${({ theme }) => theme.color.franchiseLight};
+  font-weight: 700;
+`
+const Likes = styled(Flex)`
+  gap: 0.2rem;
+  justify-content: space-evenly;
+  align-items: center;
+
+  & > svg {
+    color: red;
+  }
+`
+const Comments = styled(Flex)`
+  margin-left: 1rem;
+  gap: 0.2rem;
+  justify-content: space-evenly;
+  align-items: center;
+`
+
+const MenuTitle = styled.div`
+  font-size: 1.8rem;
+  font-weight: 700;
+`
+
+const DotWrapper = styled(Flex)`
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 1.2rem;
+`
+
+const SlideDot = styled(GoPrimitiveDot)<{ selected: boolean }>`
+  font-size: 2rem;
+  opacity: ${({ selected }) => (selected ? 1 : 0.2)};
+  cursor: pointer;
+
+  &:hover {
+    opacity: 1;
+  }
+`
+
+export default Slide


### PR DESCRIPTION
## 📌 기능 설명
메인 페이지에서 사용할 Slide 컴포넌트 구현


## 👩‍💻 요구 사항과 구현 내용

![image](https://user-images.githubusercontent.com/79133602/200133435-97564d71-61fc-444a-a9ec-ef7502ca0582.png)

### props
-  Menu[]를 props로 받습니다. 
- 인기 메뉴 리스트를 slice(0,5)한 다음 props로 넘겨주면  인기 커스텀 TOP5를 만들 수 있습니다. 

### states
- currentSlide : 현재 슬라이드 menu.id 값 
- behindSlide: 현재 슬라이드 뒷면 슬라이드  menu.id 값
- prevX: 터치했을 때 x좌표 값
- slideX: 터치 후 이동한 x좌표 값

### 작동 방식

- SlideItem들을 `position: absolute`로 겹치게 한 뒤 `z-index`로 현재 SlideItem를 조작

**이미지 클릭 시**
- 해당 상세 페이지 이동

**슬라이드 좌,우  클릭 시**
- `SlidePrev`버튼을 누르면 이전 슬라이드 이동
       -> `currentSlide-1`이` z-index: 2`가 되고 나머지는 ` z-index: 0` 이 됨
- `SlideNext`버튼을 누르면 다음 슬라이드 이동
       ->  `currentSlide+1`이 `z-index: 2`가 되고 나머지는 ` z-index: 0` 이 됨

**터치 이동 시(모바일)**

- 오른쪽에서 왼쪽으로 터치하면, 이전 슬라이드 이동
       ->`currentSlide-1`이 뒷면이라 `z-index: 1` 이 되고
       ->터치가 종료되면 , `currentSlide-1`이 z-index: 2로 앞면이 됨
- 왼쪽에서 오른쪽으로 터치하면, 다음 슬라이드 이동
       ->`currentSlide+1`이 뒷면이라 `z-index: 1` 이 되고
       ->터치가 종료되면 , `currentSlide+1`이 z-index: 2로 앞면이 됨

### 사용 예시

```jsx
    <BannerContainer/>
    <Title>인기 커스텀 메뉴 TOP5</Title>
    <Slide menuList={popularMenuList|| []} />
    <MenuCardList menuList={menuList || []} divRef={ref} />
```

## 궁금한 점
- 현재 SlideItem의 position: absolute 속성 떄문에 부모인 SlideContainer의 height가 기본 값 0이 됩니다.
- 그래서 어쩔 수 없이  height: 62vh를 줬는데 이 보다 더 나은 방법이 있다면 알려주세요.



## 구현 결과

### 마우스 클릭


https://user-images.githubusercontent.com/79133602/200134209-e1c812e7-058d-477c-8d98-180be0ec4897.mp4


### 터치



https://user-images.githubusercontent.com/79133602/200134218-5cee3678-7697-473e-a573-bb704bf6d487.mp4

